### PR TITLE
Add AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Modernization guidelines for migrating to Swift
+
+- **Swift migration**: Convert Objective-C files under `Source/Classes/` to Swift 5. Keep the existing folder structure. Use bridging headers if some MumbleKit APIs remain in Objective-C.
+- **ARC adoption**: The project still uses manual retain/release calls (for example in `MUCertificateViewController.m`). Remove `release`/`autorelease` patterns and adopt ARC when translating to Swift.
+- **Deployment targets**: The base deployment target is iOS 12. Guard new APIs with availability checks to keep compatibility with older iOS versions.
+- **Replace deprecated APIs**: Update `UIAlertView` and other legacy UI code to modern UIKit or SwiftUI equivalents. Use `XCTest` instead of `SenTestingKit`.
+- **Storyboard & Auto Layout**: Migrate nibs to storyboards and add Auto Layout constraints as needed.
+- **Audio**: Preserve existing audio features while updating to use `AVAudioSession` / `AVAudioEngine` as appropriate. Maintain interoperability with MumbleKit.
+- **Submodules**: The repo contains git submodules (`MumbleKit`, `Dependencies/fmdb`). Do not modify submodule contents directly. Ensure they are updated and integrated with the Swift code.
+- **Testing**: Running `xcodebuild` or the iOS simulator is not possible in this Linux environment. Mark any instructions requiring Xcode as non-executable here.
+- **Style**: Follow Swift naming conventions, use optionals and enums where sensible, and drop C-style macros.
+
+


### PR DESCRIPTION
## Summary
- create AGENTS.md with modernization guidelines for migrating to Swift
- note that tests requiring Xcode can't run in this environment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879bb02a9e083309dbe6f18dd973a67