### PR TITLE
Modernize alert code

### DIFF
--- a/Source/Classes/MUApplicationDelegate.m
+++ b/Source/Classes/MUApplicationDelegate.m
@@ -17,8 +17,7 @@
 #import <MumbleKit/MKAudio.h>
 #import <MumbleKit/MKVersion.h>
 
-@interface MUApplicationDelegate () <UIApplicationDelegate,
-                                     UIAlertViewDelegate> {
+@interface MUApplicationDelegate () <UIApplicationDelegate> {
     UIWindow                  *_window;
     UINavigationController    *_navigationController;
     MUPublicServerListFetcher *_publistFetcher;

--- a/Source/Classes/MUCertificateCreationView.m
+++ b/Source/Classes/MUCertificateCreationView.m
@@ -14,8 +14,15 @@
 static void ShowAlertDialog(NSString *title, NSString *msg) {
     dispatch_async(dispatch_get_main_queue(), ^{
         NSString *ok = NSLocalizedString(@"OK", nil);
-        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:title message:msg delegate:nil cancelButtonTitle:ok otherButtonTitles:nil];
-        [alert show];
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:title
+                                                                       message:msg
+                                                                preferredStyle:UIAlertControllerStyleAlert];
+        [alert addAction:[UIAlertAction actionWithTitle:ok
+                                                  style:UIAlertActionStyleCancel
+                                                handler:nil]];
+
+        UIViewController *rootVC = [UIApplication sharedApplication].keyWindow.rootViewController;
+        [rootVC presentViewController:alert animated:YES completion:nil];
         [alert release];
     });
 }

--- a/Source/Classes/MUCertificateDiskImportViewController.m
+++ b/Source/Classes/MUCertificateDiskImportViewController.m
@@ -11,8 +11,15 @@
 
 static void ShowAlertDialog(NSString *title, NSString *msg) {
     dispatch_async(dispatch_get_main_queue(), ^{
-        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:title message:msg delegate:nil cancelButtonTitle:@"OK" otherButtonTitles:nil];
-        [alert show];
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:title
+                                                                       message:msg
+                                                                preferredStyle:UIAlertControllerStyleAlert];
+        [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil)
+                                                  style:UIAlertActionStyleCancel
+                                                handler:nil]];
+
+        UIViewController *rootVC = [UIApplication sharedApplication].keyWindow.rootViewController;
+        [rootVC presentViewController:alert animated:YES completion:nil];
         [alert release];
     });
 }

--- a/Source/Classes/MUFavouriteServerListController.h
+++ b/Source/Classes/MUFavouriteServerListController.h
@@ -4,7 +4,7 @@
 
 #import "MUFavouriteServer.h"
 
-@interface MUFavouriteServerListController : UITableViewController <UIActionSheetDelegate>
+@interface MUFavouriteServerListController : UITableViewController
 - (id) init;
 - (void) presentNewFavouriteDialog;
 - (void) presentEditDialogForFavourite:(MUFavouriteServer *)favServ;


### PR DESCRIPTION
## Summary
- migrate alert helpers to `UIAlertController`
- drop deprecated delegate protocols

## Testing
- `# no tests available`

------
https://chatgpt.com/codex/tasks/task_e_6879bf7d4650833087aa705458923cbc