### PR TITLE
Switch tests to XCTest

### DIFF
--- a/Mumble.xcodeproj/project.pbxproj
+++ b/Mumble.xcodeproj/project.pbxproj
@@ -319,7 +319,7 @@
 		285D6B7016BEEFA700F239EB /* MUTextMessageProcessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MUTextMessageProcessor.m; sourceTree = "<group>"; };
 		285D6B7316BF027A00F239EB /* MUTextMessageProcessorTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MUTextMessageProcessorTest.h; path = Tests/MUTextMessageProcessorTest.h; sourceTree = "<group>"; };
 		285D6B7416BF027A00F239EB /* MUTextMessageProcessorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MUTextMessageProcessorTest.m; path = Tests/MUTextMessageProcessorTest.m; sourceTree = "<group>"; };
-		285D6B7C16BF02E900F239EB /* MumbleTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MumbleTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
+               285D6B7C16BF02E900F239EB /* MumbleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MumbleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		285D6B8316BF02E900F239EB /* MumbleTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "MumbleTests-Info.plist"; path = "Tests/MumbleTests-Info.plist"; sourceTree = SOURCE_ROOT; };
 		285D6B8516BF02E900F239EB /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		285D6B8A16BF02E900F239EB /* MumbleTests.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MumbleTests.pch; path = Tests/MumbleTests.pch; sourceTree = SOURCE_ROOT; };
@@ -650,7 +650,7 @@
 			isa = PBXGroup;
 			children = (
 				1D6058910D05DD3D006BFB54 /* Mumble.app */,
-				285D6B7C16BF02E900F239EB /* MumbleTests.octest */,
+                               285D6B7C16BF02E900F239EB /* MumbleTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -985,8 +985,8 @@
 			);
 			name = MumbleTests;
 			productName = MumbleTests;
-			productReference = 285D6B7C16BF02E900F239EB /* MumbleTests.octest */;
-			productType = "com.apple.product-type.bundle.ocunit-test";
+                       productReference = 285D6B7C16BF02E900F239EB /* MumbleTests.xctest */;
+                       productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -1412,7 +1412,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				WRAPPER_EXTENSION = octest;
+                               WRAPPER_EXTENSION = xctest;
 			};
 			name = Debug;
 		};
@@ -1442,7 +1442,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
-				WRAPPER_EXTENSION = octest;
+                               WRAPPER_EXTENSION = xctest;
 			};
 			name = Release;
 		};
@@ -1472,7 +1472,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
-				WRAPPER_EXTENSION = octest;
+                               WRAPPER_EXTENSION = xctest;
 			};
 			name = AppStore;
 		};
@@ -1502,7 +1502,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
-				WRAPPER_EXTENSION = octest;
+                               WRAPPER_EXTENSION = xctest;
 			};
 			name = BetaDist;
 		};

--- a/Tests/MUTextMessageProcessorTest.h
+++ b/Tests/MUTextMessageProcessorTest.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface MUTextMessageProcessorTest : SenTestCase
+@interface MUTextMessageProcessorTest : XCTestCase
 
 @end

--- a/Tests/MUTextMessageProcessorTest.m
+++ b/Tests/MUTextMessageProcessorTest.m
@@ -24,28 +24,28 @@
     NSString *plain = @"Hello there. Here's a link: http://www.google.com";
     NSString *expected = @"<p>Hello there. Here's a link: <a href=\"http://www.google.com\">http://www.google.com</a></p>";
     NSString *html = [MUTextMessageProcessor processedHTMLFromPlainTextMessage:plain];
-    STAssertEqualObjects(html, expected, nil);
+    XCTAssertEqualObjects(html, expected);
 }
 
 - (void) testSingleLinkWithTrailer {
     NSString *plain = @"Hello there. Here's a link: http://www.google.com, and a trailer!";
     NSString *expected = @"<p>Hello there. Here's a link: <a href=\"http://www.google.com\">http://www.google.com</a>, and a trailer!</p>";
     NSString *html = [MUTextMessageProcessor processedHTMLFromPlainTextMessage:plain];
-    STAssertEqualObjects(html, expected, nil);
+    XCTAssertEqualObjects(html, expected);
 }
 
 - (void) testMultiLink {
     NSString *plain = @"1st: http://www.a.com, 2nd: http://www.b.com";
     NSString *expected = @"<p>1st: <a href=\"http://www.a.com\">http://www.a.com</a>, 2nd: <a href=\"http://www.b.com\">http://www.b.com</a></p>";
     NSString *html = [MUTextMessageProcessor processedHTMLFromPlainTextMessage:plain];
-    STAssertEqualObjects(html, expected, nil);
+    XCTAssertEqualObjects(html, expected);
 }
 
 - (void) testPercentEncoding {
     NSString *plain = @"Hello there. Here's a link: http://www.example.com/%20a%20lot%20of%20spaces";
     NSString *expected = @"<p>Hello there. Here's a link: <a href=\"http://www.example.com/%20a%20lot%20of%20spaces\">http://www.example.com/%20a%20lot%20of%20spaces</a></p>";
     NSString *html = [MUTextMessageProcessor processedHTMLFromPlainTextMessage:plain];
-    STAssertEqualObjects(html, expected, nil);
+    XCTAssertEqualObjects(html, expected);
 }
 
 + (NSString *) plainStringFromLinks:(NSArray *)links {
@@ -89,7 +89,7 @@
     NSString *plain = [MUTextMessageProcessorTest plainStringFromLinks:links];
     NSString *expected = [MUTextMessageProcessorTest htmlStringFromLinks:links];
     NSString *html = [MUTextMessageProcessor processedHTMLFromPlainTextMessage:plain];
-    STAssertEqualObjects(html, expected, nil);
+    XCTAssertEqualObjects(html, expected);
 }
 
 - (void) testInvalidURLs {
@@ -101,7 +101,7 @@
         NSString *plain = [MUTextMessageProcessorTest plainStringFromLinks:links];
         NSString *expected = [MUTextMessageProcessorTest htmlStringFromLinks:links];
         NSString *html = [MUTextMessageProcessor processedHTMLFromPlainTextMessage:plain];
-        STAssertFalse([html isEqualToString:expected], @"got '%@', did not expect '%@'", html, expected);
+        XCTAssertFalse([html isEqualToString:expected], @"got '%@', did not expect '%@'", html, expected);
     }
 }
 


### PR DESCRIPTION
## Summary
- migrate MUTextMessageProcessor tests to XCTest
- update assertion macros
- configure the test target in `Mumble.xcodeproj` for XCTest

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879bf80cccc8330b96b6aa0ef89c97a