### PR TITLE
Use WKNavigationDelegate in MULegalViewController

### DIFF
--- a/Source/Classes/MULegalViewController.m
+++ b/Source/Classes/MULegalViewController.m
@@ -6,7 +6,7 @@
 
 @import WebKit.WKWebView;
 
-@interface MULegalViewController () <UIWebViewDelegate> {
+@interface MULegalViewController () <WKNavigationDelegate> {
     IBOutlet WKWebView *_webView;
 }
 @end
@@ -18,6 +18,11 @@
         // ...
     }
     return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    _webView.navigationDelegate = self;
 }
 
 - (void) viewWillAppear:(BOOL)animated {
@@ -32,6 +37,23 @@
 
 - (void) doneButtonClicked:(id)sender {
     [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+#pragma mark - WKNavigationDelegate
+
+- (void)webView:(WKWebView *)webView
+decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction
+decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
+    NSURL *url = navigationAction.request.URL;
+    if (navigationAction.navigationType == WKNavigationTypeLinkActivated && url) {
+        UIApplication *app = [UIApplication sharedApplication];
+        if ([app canOpenURL:url]) {
+            [app openURL:url options:@{} completionHandler:nil];
+            decisionHandler(WKNavigationActionPolicyCancel);
+            return;
+        }
+    }
+    decisionHandler(WKNavigationActionPolicyAllow);
 }
 
 @end

--- a/Source/Classes/MULegalViewController.xib
+++ b/Source/Classes/MULegalViewController.xib
@@ -27,6 +27,9 @@
                         <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
                         <wkPreferences key="preferences" javaScriptEnabled="NO"/>
                     </wkWebViewConfiguration>
+                    <connections>
+                        <outlet property="navigationDelegate" destination="-1" id="ykj-JY-pXx"/>
+                    </connections>
                 </wkWebView>
             </subviews>
             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
## Summary
- remove deprecated `UIWebViewDelegate` conformance
- wire up WKWebView to use `WKNavigationDelegate`
- add delegate handling for external links

## Testing
- `clang -fobjc-arc -fsyntax-only -x objective-c -I Source/Classes Source/Classes/MULegalViewController.m` *(fails: -fobjc-arc is not supported on platforms using the legacy runtime)*

------
https://chatgpt.com/codex/tasks/task_e_6879bf84bbdc8330b752da2549017ff6