### PR TITLE
Update README tasks

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,10 +27,8 @@ Completed tasks
 
 Open tasks
 ==========
-- Remove unused Objective-C files left over from the pre-Swift codebase.
-- Convert the final remaining xib into a storyboard.
-- Convert remaining Objective-C controllers (e.g., MUPreferencesViewController, MUConnectionController) to Swift.
-- Modernize audio handling with AVAudioSession.
+- Migrate the remaining Objective-C codebase to Swift.
+- Adopt modern audio APIs such as AVAudioSession and AVAudioEngine.
 
 Building it
 ===========


### PR DESCRIPTION
## Summary
- remove outdated Objective-C and xib tasks from the open list
- add goals to migrate remaining Objective-C code to Swift and adopt modern audio APIs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a53dad7c08330b041d5d6d7449494