### PR TITLE
Add AVAudioEngine capture pipeline for voice controls

### DIFF
--- a/Source/Classes/MUApplicationDelegate.m
+++ b/Source/Classes/MUApplicationDelegate.m
@@ -13,6 +13,7 @@
 #import "MURemoteControlServer.h"
 #import "MUImage.h"
 #import "MUBackgroundView.h"
+#import "MUAudioCaptureManager.h"
 
 #import <MumbleKit/MKAudio.h>
 #import <MumbleKit/MKVersion.h>
@@ -232,7 +233,11 @@
     
     settings.opusForceCELTMode = [defaults boolForKey:@"AudioOpusCodecForceCELTMode"];
     settings.audioMixerDebug = [defaults boolForKey:@"AudioMixerDebug"];
-    
+
+    MUAudioCaptureManager *captureManager = [MUAudioCaptureManager sharedManager];
+    [captureManager configureFromDefaults];
+    [captureManager start];
+
     MKAudio *audio = [MKAudio sharedAudio];
     [audio updateAudioSettings:&settings];
     [audio restart];
@@ -278,7 +283,8 @@
     if (!_connectionActive) {
         NSLog(@"MumbleApplicationDelegate: Not connected to a server. Stopping MKAudio.");
         [[MKAudio sharedAudio] stop];
-        
+        [[MUAudioCaptureManager sharedManager] stop];
+
 #ifdef ENABLE_REMOTE_CONTROL
         // Also terminate the remote control server.
         [[MURemoteControlServer sharedRemoteControlServer] stop];
@@ -297,6 +303,7 @@
     if (![[MKAudio sharedAudio] isRunning]) {
         NSLog(@"MumbleApplicationDelegate: MKAudio not running. Starting it.");
         [[MKAudio sharedAudio] start];
+        [[MUAudioCaptureManager sharedManager] start];
         
 #if ENABLE_REMOTE_CONTROL
         // Re-start the remote control server.

--- a/Source/Classes/MUAudioBarView.m
+++ b/Source/Classes/MUAudioBarView.m
@@ -5,7 +5,7 @@
 #import "MUAudioBarView.h"
 #import "MUColor.h"
 
-#import <MumbleKit/MKAudio.h>
+#import "MUAudioCaptureManager.h"
 
 @interface MUAudioBarView () {
     CGFloat _below;
@@ -106,14 +106,14 @@
 }
 
 - (void) tickTock {
-    MKAudio *audio = [MKAudio sharedAudio];
+    MUAudioCaptureManager *captureManager = [MUAudioCaptureManager sharedManager];
     NSString *kind = [[NSUserDefaults standardUserDefaults] objectForKey:@"AudioVADKind"];
     if (![[NSUserDefaults standardUserDefaults] boolForKey:@"AudioPreprocessor"])
         kind = @"amplitude";
     if ([kind isEqualToString:@"snr"]) {
-        _value = [audio speechProbablity];
+        _value = [captureManager speechProbability];
     } else {
-        _value = ([audio peakCleanMic] + 96.0)/96.0;
+        _value = [captureManager meterLevel];
     }
     [self setNeedsDisplay];
 }

--- a/Source/Classes/MUAudioCaptureManager.h
+++ b/Source/Classes/MUAudioCaptureManager.h
@@ -1,0 +1,51 @@
+// Copyright 2024 The 'Mumble for iOS' Developers.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, MUTransmitMode) {
+    MUTransmitModeContinuous = 0,
+    MUTransmitModePushToTalk,
+    MUTransmitModeVAD,
+};
+
+/// Centralized capture pipeline built on AVAudioEngine/AVAudioRecorder.
+@interface MUAudioCaptureManager : NSObject
+
+@property (nonatomic, readonly) MUTransmitMode transmitMode;
+@property (nonatomic, readonly) float vadMin;
+@property (nonatomic, readonly) float vadMax;
+@property (nonatomic, readonly) float meterLevel;
+@property (nonatomic, readonly) float speechProbability;
+@property (nonatomic, readonly, getter=isTransmitting) BOOL transmitting;
+
++ (instancetype)sharedManager;
+
+/// Applies defaults for transmit mode, thresholds, and encoder quality.
+- (void)configureFromDefaults;
+/// Updates only the transmit mode from defaults.
+- (void)refreshTransmitMode;
+/// Updates only the VAD thresholds from defaults.
+- (void)refreshVADThresholds;
+/// Refreshes encoder/format hints from defaults.
+- (void)refreshEncoderPreferences;
+
+/// Starts the audio engine/recorder backing the capture pipeline.
+- (void)start;
+/// Stops the audio engine/recorder backing the capture pipeline.
+- (void)stop;
+
+/// Push-to-talk control entry points.
+- (void)beginPushToTalk;
+- (void)endPushToTalk;
+
+/// Allows UI components to receive metering callbacks on the main thread.
+- (void)setMeteringHandler:(dispatch_block_t _Nullable)handler;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Source/Classes/MUAudioCaptureManager.m
+++ b/Source/Classes/MUAudioCaptureManager.m
@@ -1,0 +1,232 @@
+// Copyright 2024 The 'Mumble for iOS' Developers.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#import "MUAudioCaptureManager.h"
+#import <math.h>
+
+static const float kMinimumMeterPowerDb = -96.0f;
+static NSString * const kAudioMeterUpdateNotification = @"MUAudioCaptureManagerMeterUpdate";
+
+@interface MUAudioCaptureManager ()
+@property (nonatomic, strong) AVAudioEngine *engine;
+@property (nonatomic, strong) AVAudioRecorder *recorder;
+@property (nonatomic, strong) AVAudioFormat *inputFormat;
+@property (nonatomic, assign) MUTransmitMode transmitMode;
+@property (nonatomic, assign) float vadMin;
+@property (nonatomic, assign) float vadMax;
+@property (nonatomic, assign) float meterLevel;
+@property (nonatomic, assign) float speechProbability;
+@property (nonatomic, assign, getter=isTransmitting) BOOL transmitting;
+@property (nonatomic, assign) BOOL tapInstalled;
+@property (nonatomic, copy) dispatch_block_t meteringHandler;
+@end
+
+@implementation MUAudioCaptureManager
+
++ (instancetype)sharedManager {
+    static dispatch_once_t onceToken;
+    static MUAudioCaptureManager *manager;
+    dispatch_once(&onceToken, ^{
+        manager = [[MUAudioCaptureManager alloc] init];
+    });
+    return manager;
+}
+
+- (instancetype)init {
+    if ((self = [super init])) {
+        _engine = [[AVAudioEngine alloc] init];
+        _meterLevel = 0.0f;
+        _vadMin = 0.0f;
+        _vadMax = 1.0f;
+        _transmitMode = MUTransmitModeVAD;
+        _inputFormat = [_engine.inputNode inputFormatForBus:0];
+    }
+    return self;
+}
+
+#pragma mark - Configuration
+
+- (void)configureFromDefaults {
+    [self refreshTransmitMode];
+    [self refreshVADThresholds];
+    [self refreshEncoderPreferences];
+}
+
+- (void)refreshTransmitMode {
+    NSString *method = [[NSUserDefaults standardUserDefaults] stringForKey:@"AudioTransmitMethod"];
+    if ([method isEqualToString:@"continuous"]) {
+        self.transmitMode = MUTransmitModeContinuous;
+    } else if ([method isEqualToString:@"ptt"]) {
+        self.transmitMode = MUTransmitModePushToTalk;
+    } else {
+        self.transmitMode = MUTransmitModeVAD;
+    }
+}
+
+- (void)refreshVADThresholds {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    self.vadMin = [defaults floatForKey:@"AudioVADBelow"];
+    self.vadMax = [defaults floatForKey:@"AudioVADAbove"];
+}
+
+- (void)refreshEncoderPreferences {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSString *quality = [defaults stringForKey:@"AudioQualityKind"];
+    double sampleRate = 48000.0;
+    if ([quality isEqualToString:@"low"]) {
+        sampleRate = 16000.0;
+    } else if ([quality isEqualToString:@"balanced"]) {
+        sampleRate = 40000.0;
+    } else if ([quality isEqualToString:@"high"] || [quality isEqualToString:@"opus"]) {
+        sampleRate = 72000.0;
+    }
+
+    NSError *error = nil;
+    AVAudioSession *session = [AVAudioSession sharedInstance];
+    [session setCategory:AVAudioSessionCategoryPlayAndRecord
+             withOptions:AVAudioSessionCategoryOptionAllowBluetooth | AVAudioSessionCategoryOptionMixWithOthers
+                   error:&error];
+    [session setPreferredSampleRate:sampleRate error:&error];
+    [session setPreferredIOBufferDuration:0.02 error:&error];
+    [session setActive:YES error:&error];
+
+    self.inputFormat = [[AVAudioFormat alloc] initStandardFormatWithSampleRate:sampleRate channels:1];
+
+    NSDictionary *settings = @{ AVFormatIDKey : @(kAudioFormatMPEG4AAC),
+                                AVSampleRateKey : @(sampleRate),
+                                AVNumberOfChannelsKey : @(1),
+                                AVEncoderBitRateKey : @((NSInteger)sampleRate),
+                                AVEncoderAudioQualityKey : @(AVAudioQualityHigh)};
+    self.recorder = [[AVAudioRecorder alloc] initWithURL:[NSURL fileURLWithPath:@"/dev/null"]
+                                                settings:settings
+                                                   error:&error];
+    self.recorder.meteringEnabled = YES;
+    if (!error) {
+        [self.recorder prepareToRecord];
+    }
+}
+
+#pragma mark - Engine lifecycle
+
+- (void)start {
+    [self installTapIfNeeded];
+    if (![self.engine isRunning]) {
+        NSError *error = nil;
+        [self.engine startAndReturnError:&error];
+        if (error) {
+            NSLog(@"MUAudioCaptureManager: failed to start engine: %@", error);
+        }
+    }
+    if (self.transmitMode == MUTransmitModeContinuous) {
+        self.transmitting = YES;
+    }
+    if (self.transmitMode == MUTransmitModePushToTalk && self.recorder) {
+        [self.recorder record];
+    }
+}
+
+- (void)stop {
+    if (self.tapInstalled) {
+        [self.engine.inputNode removeTapOnBus:0];
+        self.tapInstalled = NO;
+    }
+    [self.engine stop];
+    if (self.recorder.isRecording) {
+        [self.recorder stop];
+    }
+    self.transmitting = NO;
+}
+
+#pragma mark - Push-to-talk
+
+- (void)beginPushToTalk {
+    if (self.transmitMode != MUTransmitModePushToTalk) {
+        return;
+    }
+    self.transmitting = YES;
+    if (self.recorder && !self.recorder.isRecording) {
+        [self.recorder record];
+    }
+}
+
+- (void)endPushToTalk {
+    if (self.transmitMode != MUTransmitModePushToTalk) {
+        return;
+    }
+    self.transmitting = NO;
+    if (self.recorder.isRecording) {
+        [self.recorder stop];
+    }
+}
+
+#pragma mark - Metering
+
+- (void)installTapIfNeeded {
+    AVAudioInputNode *input = self.engine.inputNode;
+    if (!input) {
+        return;
+    }
+    if (self.tapInstalled) {
+        return;
+    }
+
+    __weak typeof(self) weakSelf = self;
+    [input installTapOnBus:0 bufferSize:1024 format:self.inputFormat block:^(AVAudioPCMBuffer * _Nonnull buffer, AVAudioTime * _Nonnull when) {
+        [weakSelf processBuffer:buffer];
+    }];
+    self.tapInstalled = YES;
+}
+
+- (void)processBuffer:(AVAudioPCMBuffer *)buffer {
+    AVAudioFrameCount frameLength = buffer.frameLength;
+    if (frameLength == 0) {
+        return;
+    }
+
+    float *data = buffer.floatChannelData[0];
+    float sum = 0.0f;
+    for (AVAudioFrameCount i = 0; i < frameLength; ++i) {
+        sum += data[i] * data[i];
+    }
+    float rms = sqrtf(sum / (float)frameLength);
+    float powerDb = 20.0f * log10f(rms);
+    if (!isfinite(powerDb)) {
+        powerDb = kMinimumMeterPowerDb;
+    }
+    float normalizedPower = (powerDb - kMinimumMeterPowerDb) / fabsf(kMinimumMeterPowerDb);
+    normalizedPower = fmaxf(0.0f, fminf(1.0f, normalizedPower));
+
+    self.meterLevel = normalizedPower;
+
+    if (self.transmitMode == MUTransmitModeVAD) {
+        float probability = 0.0f;
+        if (self.vadMax > self.vadMin) {
+            probability = (normalizedPower - self.vadMin) / (self.vadMax - self.vadMin);
+            probability = fmaxf(0.0f, fminf(1.0f, probability));
+        }
+        self.speechProbability = probability;
+        BOOL shouldTransmit = normalizedPower >= self.vadMax;
+        BOOL shouldStop = normalizedPower <= self.vadMin;
+        if (shouldTransmit) {
+            self.transmitting = YES;
+        } else if (shouldStop) {
+            self.transmitting = NO;
+        }
+    } else if (self.transmitMode == MUTransmitModeContinuous) {
+        self.transmitting = YES;
+    }
+
+    dispatch_block_t handler = self.meteringHandler;
+    if (handler) {
+        dispatch_async(dispatch_get_main_queue(), handler);
+    }
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:kAudioMeterUpdateNotification object:self];
+}
+
+- (void)setMeteringHandler:(dispatch_block_t)handler {
+    _meteringHandler = [handler copy];
+}
+
+@end

--- a/Source/Classes/MURemoteControlServer.m
+++ b/Source/Classes/MURemoteControlServer.m
@@ -10,6 +10,7 @@
 #import "MURemoteControlServer.h"
 
 #import <MumbleKit/MKAudio.h>
+#import "MUAudioCaptureManager.h"
 
 @interface MURemoteControlServer () {
     NSMutableArray *_activeSocks;
@@ -41,6 +42,11 @@ static void *serverThread(void *udata) {
         unsigned char code = action & ~0x1;
         if (code == 0) { // PTT
             MKAudio *audio = [MKAudio sharedAudio];
+            if (on) {
+                [[MUAudioCaptureManager sharedManager] beginPushToTalk];
+            } else {
+                [[MUAudioCaptureManager sharedManager] endPushToTalk];
+            }
             [audio setForceTransmit:on > 0];
         }
     }

--- a/Source/Classes/MUServerRootViewController.m
+++ b/Source/Classes/MUServerRootViewController.m
@@ -17,6 +17,7 @@
 #import <MumbleKit/MKServerModel.h>
 #import <MumbleKit/MKCertificate.h>
 #import <MumbleKit/MKAudio.h>
+#import "MUAudioCaptureManager.h"
 
 #import "MKNumberBadgeView.h"
 
@@ -152,6 +153,7 @@
 
     [_segmentedControl performSelector:@selector(bringSubviewToFront:) withObject:_numberBadgeView afterDelay:0.0f];
 
+    [[MUAudioCaptureManager sharedManager] endPushToTalk];
     [[MKAudio sharedAudio] setForceTransmit:NO];
 }
 

--- a/Source/Classes/MUServerViewController.m
+++ b/Source/Classes/MUServerViewController.m
@@ -10,6 +10,7 @@
 #import "MUServerTableViewCell.h"
 
 #import <MumbleKit/MKAudio.h>
+#import "MUAudioCaptureManager.h"
 
 #pragma mark -
 #pragma mark MUChannelNavigationItem
@@ -579,11 +580,13 @@
 
 - (void) talkOn:(UIButton *)button {
     [button setAlpha:1.0f];
+    [[MUAudioCaptureManager sharedManager] beginPushToTalk];
     [[MKAudio sharedAudio] setForceTransmit:YES];
 }
 
 - (void) talkOff:(UIButton *)button {
     [button setAlpha:0.80f];
+    [[MUAudioCaptureManager sharedManager] endPushToTalk];
     [[MKAudio sharedAudio] setForceTransmit:NO];
 }
 
@@ -613,6 +616,7 @@
 
 - (void) appDidEnterBackground:(NSNotification *)notification {
     // Force Push-to-Talk to stop when the app is backgrounded.
+    [[MUAudioCaptureManager sharedManager] endPushToTalk];
     [[MKAudio sharedAudio] setForceTransmit:NO];
     
     // Reload the table view to re-render the talk state for the user


### PR DESCRIPTION
## Summary
- add a centralized AVAudioEngine-based capture manager with VAD metering and encoder configuration derived from user preferences
- update push-to-talk, remote control hooks, and VAD meter UI to drive the new capture pipeline while keeping MKAudio in sync
- start and stop the capture pipeline alongside existing audio lifecycle management

## Testing
- not run (iOS simulator/Xcode not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a4aaaef808330a3978a3be27a316a)