### PR TITLE
Align SwiftUI skill name and add SwiftUI expert references

### DIFF
--- a/.codex/skills/swiftui-expert-skill/SKILL.md
+++ b/.codex/skills/swiftui-expert-skill/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: swiftui-expert
+description: Write, review, or improve SwiftUI code following best practices for state management, view composition, performance, modern APIs, Swift concurrency, and iOS 26+ Liquid Glass adoption. Use when building new SwiftUI features, refactoring existing views, reviewing code quality, or adopting modern SwiftUI patterns.
+---
+
+# SwiftUI Expert Skill
+
+## Overview
+Use this skill to build, review, or improve SwiftUI features with correct state management, modern API usage, Swift concurrency best practices, optimal view composition, and iOS 26+ Liquid Glass styling. Prioritize native APIs, Apple design guidance, and performance-conscious patterns. This skill focuses on facts and best practices without enforcing specific architectural patterns.
+
+## Workflow Decision Tree
+
+### 1) Review existing SwiftUI code
+- Check property wrapper usage against the selection guide (see `references/state-management.md`)
+- Verify modern API usage (see `references/modern-apis.md`)
+- Verify view composition follows extraction rules (see `references/view-structure.md`)
+- Check performance patterns are applied (see `references/performance-patterns.md`)
+- Verify list patterns use stable identity (see `references/list-patterns.md`)
+- Inspect Liquid Glass usage for correctness and consistency (see `references/liquid-glass.md`)
+- Validate iOS 26+ availability handling with sensible fallbacks
+
+### 2) Improve existing SwiftUI code
+- Audit state management for correct wrapper selection (prefer `@Observable` over `ObservableObject`)
+- Replace deprecated APIs with modern equivalents (see `references/modern-apis.md`)
+- Extract complex views into separate subviews (see `references/view-structure.md`)
+- Refactor hot paths to minimize redundant state updates (see `references/performance-patterns.md`)
+- Ensure ForEach uses stable identity (see `references/list-patterns.md`)
+- Suggest image downsampling when `UIImage(data:)` is used (as optional optimization, see `references/image-optimization.md`)
+- Adopt Liquid Glass only when explicitly requested by the user
+
+### 3) Implement new SwiftUI feature
+- Design data flow first: identify owned vs injected state (see `references/state-management.md`)
+- Use modern APIs (no deprecated modifiers or patterns, see `references/modern-apis.md`)
+- Use `@Observable` for shared state (with `@MainActor` if not using default actor isolation)
+- Structure views for optimal diffing (extract subviews early, keep views small, see `references/view-structure.md`)
+- Separate business logic into testable models (see `references/layout-best-practices.md`)
+- Apply glass effects after layout/appearance modifiers (see `references/liquid-glass.md`)
+- Gate iOS 26+ features with `#available` and provide fallbacks
+
+## Core Guidelines
+
+### State Management
+- **Always prefer `@Observable` over `ObservableObject`** for new code
+- **Mark `@Observable` classes with `@MainActor`** unless using default actor isolation
+- **Always mark `@State` and `@StateObject` as `private`** (makes dependencies clear)
+- **Never declare passed values as `@State` or `@StateObject`** (they only accept initial values)
+- Use `@State` with `@Observable` classes (not `@StateObject`)
+- `@Binding` only when child needs to **modify** parent state
+- `@Bindable` for injected `@Observable` objects needing bindings
+- Use `let` for read-only values; `var` + `.onChange()` for reactive reads
+- Legacy: `@StateObject` for owned `ObservableObject`; `@ObservedObject` for injected
+- Nested `ObservableObject` doesn't work (pass nested objects directly); `@Observable` handles nesting fine
+
+### Modern APIs
+- Use `foregroundStyle()` instead of `foregroundColor()`
+- Use `clipShape(.rect(cornerRadius:))` instead of `cornerRadius()`
+- Use `Tab` API instead of `tabItem()`
+- Use `Button` instead of `onTapGesture()` (unless need location/count)
+- Use `NavigationStack` instead of `NavigationView`
+- Use `navigationDestination(for:)` for type-safe navigation
+- Use two-parameter or no-parameter `onChange()` variant
+- Use `ImageRenderer` for rendering SwiftUI views
+- Use `.sheet(item:)` instead of `.sheet(isPresented:)` for model-based content
+- Sheets should own their actions and call `dismiss()` internally
+- Use `ScrollViewReader` for programmatic scrolling with stable IDs
+- Avoid `UIScreen.main.bounds` for sizing
+- Avoid `GeometryReader` when alternatives exist (e.g., `containerRelativeFrame()`)
+
+### Swift Best Practices
+- Use modern Text formatting (`.format` parameters, not `String(format:)`)
+- Use `localizedStandardContains()` for user-input filtering (not `contains()`)
+- Prefer static member lookup (`.blue` vs `Color.blue`)
+- Use `.task` modifier for automatic cancellation of async work
+- Use `.task(id:)` for value-dependent tasks
+
+### View Composition
+- **Prefer modifiers over conditional views** for state changes (maintains view identity)
+- Extract complex views into separate subviews for better readability and performance
+- Keep views small for optimal performance
+- Keep view `body` simple and pure (no side effects or complex logic)
+- Use `@ViewBuilder` functions only for small, simple sections
+- Prefer `@ViewBuilder let content: Content` over closure-based content properties
+- Separate business logic into testable models (not about enforcing architectures)
+- Action handlers should reference methods, not contain inline logic
+- Use relative layout over hard-coded constants
+- Views should work in any context (don't assume screen size or presentation style)
+
+### Performance
+- Pass only needed values to views (avoid large "config" or "context" objects)
+- Eliminate unnecessary dependencies to reduce update fan-out
+- Check for value changes before assigning state in hot paths
+- Avoid redundant state updates in `onReceive`, `onChange`, scroll handlers
+- Minimize work in frequently executed code paths
+- Use `LazyVStack`/`LazyHStack` for large lists
+- Use stable identity for `ForEach` (never `.indices` for dynamic content)
+- Ensure constant number of views per `ForEach` element
+- Avoid inline filtering in `ForEach` (prefilter and cache)
+- Avoid `AnyView` in list rows
+- Consider POD views for fast diffing (or wrap expensive views in POD parents)
+- Suggest image downsampling when `UIImage(data:)` is encountered (as optional optimization)
+- Avoid layout thrash (deep hierarchies, excessive `GeometryReader`)
+- Gate frequent geometry updates by thresholds
+- Use `Self._printChanges()` to debug unexpected view updates
+
+### Liquid Glass (iOS 26+)
+**Only adopt when explicitly requested by the user.**
+- Use native `glassEffect`, `GlassEffectContainer`, and glass button styles
+- Wrap multiple glass elements in `GlassEffectContainer`
+- Apply `.glassEffect()` after layout and visual modifiers
+- Use `.interactive()` only for tappable/focusable elements
+- Use `glassEffectID` with `@Namespace` for morphing transitions
+
+## Quick Reference
+
+### Property Wrapper Selection (Modern)
+| Wrapper | Use When |
+|---------|----------|
+| `@State` | Internal view state (must be `private`), or owned `@Observable` class |
+| `@Binding` | Child modifies parent's state |
+| `@Bindable` | Injected `@Observable` needing bindings |
+| `let` | Read-only value from parent |
+| `var` | Read-only value watched via `.onChange()` |
+
+**Legacy (Pre-iOS 17):**
+| Wrapper | Use When |
+|---------|----------|
+| `@StateObject` | View owns an `ObservableObject` (use `@State` with `@Observable` instead) |
+| `@ObservedObject` | View receives an `ObservableObject` |
+
+### Modern API Replacements
+| Deprecated | Modern Alternative |
+|------------|-------------------|
+| `foregroundColor()` | `foregroundStyle()` |
+| `cornerRadius()` | `clipShape(.rect(cornerRadius:))` |
+| `tabItem()` | `Tab` API |
+| `onTapGesture()` | `Button` (unless need location/count) |
+| `NavigationView` | `NavigationStack` |
+| `onChange(of:) { value in }` | `onChange(of:) { old, new in }` or `onChange(of:) { }` |
+| `fontWeight(.bold)` | `bold()` |
+| `GeometryReader` | `containerRelativeFrame()` or `visualEffect()` |
+| `showsIndicators: false` | `.scrollIndicators(.hidden)` |
+| `String(format: "%.2f", value)` | `Text(value, format: .number.precision(.fractionLength(2)))` |
+| `string.contains(search)` | `string.localizedStandardContains(search)` (for user input) |
+
+### Liquid Glass Patterns
+```swift
+// Basic glass effect with fallback
+if #available(iOS 26, *) {
+    content
+        .padding()
+        .glassEffect(.regular.interactive(), in: .rect(cornerRadius: 16))
+} else {
+    content
+        .padding()
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16))
+}
+
+// Grouped glass elements
+GlassEffectContainer(spacing: 24) {
+    HStack(spacing: 24) {
+        GlassButton1()
+        GlassButton2()
+    }
+}
+
+// Glass buttons
+Button("Confirm") { }
+    .buttonStyle(.glassProminent)
+```
+
+## Review Checklist
+
+### State Management
+- [ ] Using `@Observable` instead of `ObservableObject` for new code
+- [ ] `@Observable` classes marked with `@MainActor` (if needed)
+- [ ] Using `@State` with `@Observable` classes (not `@StateObject`)
+- [ ] `@State` and `@StateObject` properties are `private`
+- [ ] Passed values NOT declared as `@State` or `@StateObject`
+- [ ] `@Binding` only where child modifies parent state
+- [ ] `@Bindable` for injected `@Observable` needing bindings
+- [ ] Nested `ObservableObject` avoided (or passed directly to child views)
+
+### Modern APIs (see `references/modern-apis.md`)
+- [ ] Using `foregroundStyle()` instead of `foregroundColor()`
+- [ ] Using `clipShape(.rect(cornerRadius:))` instead of `cornerRadius()`
+- [ ] Using `Tab` API instead of `tabItem()`
+- [ ] Using `Button` instead of `onTapGesture()` (unless need location/count)
+- [ ] Using `NavigationStack` instead of `NavigationView`
+- [ ] Avoiding `UIScreen.main.bounds`
+- [ ] Using alternatives to `GeometryReader` when possible
+- [ ] Button images include text labels for accessibility
+
+### Sheets & Navigation (see `references/sheet-navigation-patterns.md`)
+- [ ] Using `.sheet(item:)` for model-based sheets
+- [ ] Sheets own their actions and dismiss internally
+- [ ] Using `navigationDestination(for:)` for type-safe navigation
+
+### ScrollView (see `references/scroll-patterns.md`)
+- [ ] Using `ScrollViewReader` with stable IDs for programmatic scrolling
+- [ ] Using `.scrollIndicators(.hidden)` instead of initializer parameter
+
+### Text & Formatting (see `references/text-formatting.md`)
+- [ ] Using modern Text formatting (not `String(format:)`)
+- [ ] Using `localizedStandardContains()` for search filtering
+
+### View Structure (see `references/view-structure.md`)
+- [ ] Using modifiers instead of conditionals for state changes
+- [ ] Complex views extracted to separate subviews
+- [ ] Views kept small for performance
+- [ ] Container views use `@ViewBuilder let content: Content`
+
+### Performance (see `references/performance-patterns.md`)
+- [ ] View `body` kept simple and pure (no side effects)
+- [ ] Passing only needed values (not large config objects)
+- [ ] Eliminating unnecessary dependencies
+- [ ] State updates check for value changes before assigning
+- [ ] Hot paths minimize state updates
+- [ ] No object creation in `body`
+- [ ] Heavy computation moved out of `body`
+
+### List Patterns (see `references/list-patterns.md`)
+- [ ] ForEach uses stable identity (not `.indices`)
+- [ ] Constant number of views per ForEach element
+- [ ] No inline filtering in ForEach
+- [ ] No `AnyView` in list rows
+
+### Layout (see `references/layout-best-practices.md`)
+- [ ] Avoiding layout thrash (deep hierarchies, excessive GeometryReader)
+- [ ] Gating frequent geometry updates by thresholds
+- [ ] Business logic separated into testable models
+- [ ] Action handlers reference methods (not inline logic)
+- [ ] Using relative layout (not hard-coded constants)
+- [ ] Views work in any context (context-agnostic)
+
+### Liquid Glass (iOS 26+)
+- [ ] `#available(iOS 26, *)` with fallback for Liquid Glass
+- [ ] Multiple glass views wrapped in `GlassEffectContainer`
+- [ ] `.glassEffect()` applied after layout/appearance modifiers
+- [ ] `.interactive()` only on user-interactable elements
+- [ ] Shapes and tints consistent across related elements
+
+## References
+- `references/state-management.md` - Property wrappers and data flow (prefer `@Observable`)
+- `references/view-structure.md` - View composition, extraction, and container patterns
+- `references/performance-patterns.md` - Performance optimization techniques and anti-patterns
+- `references/list-patterns.md` - ForEach identity, stability, and list best practices
+- `references/layout-best-practices.md` - Layout patterns, context-agnostic views, and testability
+- `references/modern-apis.md` - Modern API usage and deprecated replacements
+- `references/sheet-navigation-patterns.md` - Sheet presentation and navigation patterns
+- `references/scroll-patterns.md` - ScrollView patterns and programmatic scrolling
+- `references/text-formatting.md` - Modern text formatting and string operations
+- `references/image-optimization.md` - AsyncImage, image downsampling, and optimization
+- `references/liquid-glass.md` - iOS 26+ Liquid Glass API
+
+## Philosophy
+
+This skill focuses on **facts and best practices**, not architectural opinions:
+- We don't enforce specific architectures (e.g., MVVM, VIPER)
+- We do encourage separating business logic for testability
+- We prioritize modern APIs over deprecated ones
+- We emphasize thread safety with `@MainActor` and `@Observable`
+- We optimize for performance and maintainability
+- We follow Apple's Human Interface Guidelines and API design patterns

--- a/.codex/skills/swiftui-expert-skill/references/image-optimization.md
+++ b/.codex/skills/swiftui-expert-skill/references/image-optimization.md
@@ -1,0 +1,286 @@
+# SwiftUI Image Optimization Reference
+
+## AsyncImage Best Practices
+
+### Basic AsyncImage with Phase Handling
+
+```swift
+// Good - handles loading and error states
+AsyncImage(url: imageURL) { phase in
+    switch phase {
+    case .empty:
+        ProgressView()
+    case .success(let image):
+        image
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+    case .failure:
+        Image(systemName: "photo")
+            .foregroundStyle(.secondary)
+    @unknown default:
+        EmptyView()
+    }
+}
+.frame(width: 200, height: 200)
+```
+
+### AsyncImage with Custom Placeholder
+
+```swift
+struct ImageView: View {
+    let url: URL?
+    
+    var body: some View {
+        AsyncImage(url: url) { phase in
+            switch phase {
+            case .empty:
+                ZStack {
+                    Color.gray.opacity(0.2)
+                    ProgressView()
+                }
+            case .success(let image):
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            case .failure:
+                ZStack {
+                    Color.gray.opacity(0.2)
+                    Image(systemName: "exclamationmark.triangle")
+                        .foregroundStyle(.secondary)
+                }
+            @unknown default:
+                EmptyView()
+            }
+        }
+        .clipShape(.rect(cornerRadius: 12))
+    }
+}
+```
+
+### AsyncImage with Transition
+
+```swift
+AsyncImage(url: imageURL) { phase in
+    switch phase {
+    case .empty:
+        ProgressView()
+    case .success(let image):
+        image
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .transition(.opacity)
+    case .failure:
+        Image(systemName: "photo")
+    @unknown default:
+        EmptyView()
+    }
+}
+.animation(.easeInOut, value: imageURL)
+```
+
+## Image Decoding and Downsampling (Optional Optimization)
+
+**When you encounter `UIImage(data:)` usage, consider suggesting image downsampling as a potential performance improvement**, especially for large images in lists or grids.
+
+### Current Pattern That Could Be Optimized
+
+```swift
+// Current pattern - decodes full image on main thread
+// Unsafe - force unwrap can crash if imageData is invalid
+Image(uiImage: UIImage(data: imageData)!)
+    .resizable()
+    .aspectRatio(contentMode: .fit)
+    .frame(width: 200, height: 200)
+```
+
+### Suggested Optimization Pattern
+
+```swift
+// Suggested optimization - decode and downsample off main thread
+struct OptimizedImageView: View {
+    let imageData: Data
+    let targetSize: CGSize
+    @State private var processedImage: UIImage?
+    
+    var body: some View {
+        Group {
+            if let processedImage {
+                Image(uiImage: processedImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            } else {
+                ProgressView()
+            }
+        }
+        .task {
+            processedImage = await decodeAndDownsample(imageData, targetSize: targetSize)
+        }
+    }
+    
+    private func decodeAndDownsample(_ data: Data, targetSize: CGSize) async -> UIImage? {
+        await Task.detached {
+            guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+                return nil
+            }
+            
+            let options: [CFString: Any] = [
+                kCGImageSourceThumbnailMaxPixelSize: max(targetSize.width, targetSize.height),
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceCreateThumbnailWithTransform: true
+            ]
+            
+            guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+                return nil
+            }
+            
+            return UIImage(cgImage: cgImage)
+        }.value
+    }
+}
+
+// Usage
+OptimizedImageView(
+    imageData: imageData,
+    targetSize: CGSize(width: 200, height: 200)
+)
+```
+
+### Reusable Image Downsampling Helper
+
+```swift
+actor ImageProcessor {
+    func downsample(data: Data, to targetSize: CGSize) -> UIImage? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+            return nil
+        }
+        
+        let maxDimension = max(targetSize.width, targetSize.height) * UIScreen.main.scale
+        
+        let options: [CFString: Any] = [
+            kCGImageSourceThumbnailMaxPixelSize: maxDimension,
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCache: false
+        ]
+        
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+            return nil
+        }
+        
+        return UIImage(cgImage: cgImage)
+    }
+}
+
+// Usage in view
+struct ImageView: View {
+    let imageData: Data
+    let targetSize: CGSize
+    @State private var image: UIImage?
+    
+    private let processor = ImageProcessor()
+    
+    var body: some View {
+        Group {
+            if let image {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            } else {
+                ProgressView()
+            }
+        }
+        .task {
+            image = await processor.downsample(data: imageData, to: targetSize)
+        }
+    }
+}
+```
+
+### When to Suggest This Optimization
+
+Mention this optimization when you see `UIImage(data:)` usage, particularly in:
+- Scrollable content (List, ScrollView with LazyVStack/LazyHStack)
+- Grid layouts with many images
+- Image galleries or carousels
+- Any scenario where large images are displayed at smaller sizes
+
+**Don't automatically apply it**—present it as an optional improvement for performance-sensitive scenarios.
+
+## SF Symbols
+
+### Using SF Symbols
+
+```swift
+// Basic symbol
+Image(systemName: "star.fill")
+    .foregroundStyle(.yellow)
+
+// With rendering mode
+Image(systemName: "heart.fill")
+    .symbolRenderingMode(.multicolor)
+
+// With variable color
+Image(systemName: "speaker.wave.3.fill")
+    .symbolRenderingMode(.hierarchical)
+    .foregroundStyle(.blue)
+
+// Animated symbols (iOS 17+)
+Image(systemName: "antenna.radiowaves.left.and.right")
+    .symbolEffect(.variableColor)
+```
+
+### SF Symbol Variants
+
+```swift
+// Circle variant
+Image(systemName: "star.circle.fill")
+
+// Square variant
+Image(systemName: "star.square.fill")
+
+// With badge
+Image(systemName: "folder.badge.plus")
+```
+
+## Image Rendering
+
+### ImageRenderer for Snapshots
+
+```swift
+// Render SwiftUI view to UIImage
+let renderer = ImageRenderer(content: myView)
+renderer.scale = UIScreen.main.scale
+
+if let uiImage = renderer.uiImage {
+    // Use the image (save, share, etc.)
+}
+
+// Render to CGImage
+if let cgImage = renderer.cgImage {
+    // Use CGImage
+}
+```
+
+### Rendering with Custom Size
+
+```swift
+let renderer = ImageRenderer(content: myView)
+renderer.proposedSize = ProposedViewSize(width: 400, height: 300)
+
+if let uiImage = renderer.uiImage {
+    // Image rendered at 400x300 points
+}
+```
+
+## Summary Checklist
+
+- [ ] Use `AsyncImage` with proper phase handling
+- [ ] Handle empty, success, and failure states
+- [ ] Consider downsampling for `UIImage(data:)` in performance-sensitive scenarios
+- [ ] Decode and downsample images off the main thread
+- [ ] Use appropriate target sizes for downsampling
+- [ ] Consider image caching for frequently accessed images
+- [ ] Use SF Symbols with appropriate rendering modes
+- [ ] Use `ImageRenderer` for rendering SwiftUI views to images
+
+**Performance Note**: Image downsampling is an optional optimization. Only suggest it when you encounter `UIImage(data:)` usage in performance-sensitive contexts like scrollable lists or grids.

--- a/.codex/skills/swiftui-expert-skill/references/layout-best-practices.md
+++ b/.codex/skills/swiftui-expert-skill/references/layout-best-practices.md
@@ -1,0 +1,312 @@
+# SwiftUI Layout Best Practices Reference
+
+## Relative Layout Over Constants
+
+**Use dynamic layout calculations instead of hard-coded values.**
+
+```swift
+// Good - relative to actual layout
+GeometryReader { geometry in
+    VStack {
+        HeaderView()
+            .frame(height: geometry.size.height * 0.2)
+        ContentView()
+    }
+}
+
+// Avoid - magic numbers that don't adapt
+VStack {
+    HeaderView()
+        .frame(height: 150)  // Doesn't adapt to different screens
+    ContentView()
+}
+```
+
+**Why**: Hard-coded values don't account for different screen sizes, orientations, or dynamic content (like status bars during phone calls).
+
+## Context-Agnostic Views
+
+**Views should work in any context.** Never assume presentation style or screen size.
+
+```swift
+// Good - adapts to given space
+struct ProfileCard: View {
+    let user: User
+    
+    var body: some View {
+        VStack {
+            Image(user.avatar)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+            Text(user.name)
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+// Avoid - assumes full screen
+struct ProfileCard: View {
+    let user: User
+    
+    var body: some View {
+        VStack {
+            Image(user.avatar)
+                .frame(width: UIScreen.main.bounds.width)  // Wrong!
+            Text(user.name)
+        }
+    }
+}
+```
+
+**Why**: Views should work as full screens, modals, sheets, popovers, or embedded content.
+
+## Own Your Container
+
+**Custom views should own static containers but not lazy/repeatable ones.**
+
+```swift
+// Good - owns static container
+struct HeaderView: View {
+    var body: some View {
+        HStack {
+            Image(systemName: "star")
+            Text("Title")
+            Spacer()
+        }
+    }
+}
+
+// Avoid - missing container
+struct HeaderView: View {
+    var body: some View {
+        Image(systemName: "star")
+        Text("Title")
+        // Caller must wrap in HStack
+    }
+}
+
+// Good - caller owns lazy container
+struct FeedView: View {
+    let items: [Item]
+    
+    var body: some View {
+        LazyVStack {
+            ForEach(items) { item in
+                ItemRow(item: item)
+            }
+        }
+    }
+}
+```
+
+## Layout Performance
+
+### Avoid Layout Thrash
+
+**Minimize deep view hierarchies and excessive layout dependencies.**
+
+```swift
+// Bad - deep nesting, excessive layout passes
+VStack {
+    HStack {
+        VStack {
+            HStack {
+                VStack {
+                    Text("Deep")
+                }
+            }
+        }
+    }
+}
+
+// Good - flatter hierarchy
+VStack {
+    Text("Shallow")
+    Text("Structure")
+}
+```
+
+**Avoid excessive `GeometryReader` and preference chains:**
+
+```swift
+// Bad - multiple geometry readers cause layout thrash
+GeometryReader { outerGeometry in
+    VStack {
+        GeometryReader { innerGeometry in
+            // Layout recalculates multiple times
+        }
+    }
+}
+
+// Good - single geometry reader or use alternatives (iOS 17+)
+containerRelativeFrame(.horizontal) { width, _ in
+    width * 0.8
+}
+```
+
+**Gate frequent geometry updates:**
+
+```swift
+// Bad - updates on every pixel change
+.onPreferenceChange(ViewSizeKey.self) { size in
+    currentSize = size
+}
+
+// Good - gate by threshold
+.onPreferenceChange(ViewSizeKey.self) { size in
+    let difference = abs(size.width - currentSize.width)
+    if difference > 10 {  // Only update if significant change
+        currentSize = size
+    }
+}
+```
+
+## View Logic and Testability
+
+### Separate View Logic from Views
+
+**Place view logic into view models or similar, so it can be tested.**
+
+> **iOS 17+**: Use `@Observable` macro with `@State` for view models.
+
+```swift
+// Good - logic in testable model (iOS 17+)
+@Observable
+@MainActor
+final class LoginViewModel {
+    var email = ""
+    var password = ""
+    var isValid: Bool {
+        !email.isEmpty && password.count >= 8
+    }
+
+    func login() async throws {
+        // Business logic here
+    }
+}
+
+struct LoginView: View {
+    @State private var viewModel = LoginViewModel()
+
+    var body: some View {
+        Form {
+            TextField("Email", text: $viewModel.email)
+            SecureField("Password", text: $viewModel.password)
+            Button("Login") {
+                Task {
+                    try? await viewModel.login()
+                }
+            }
+            .disabled(!viewModel.isValid)
+        }
+    }
+}
+```
+
+> **iOS 16 and earlier**: Use `ObservableObject` protocol with `@StateObject`.
+
+```swift
+// Good - logic in testable model (iOS 16 and earlier)
+@MainActor
+final class LoginViewModel: ObservableObject {
+    @Published var email = ""
+    @Published var password = ""
+    var isValid: Bool {
+        !email.isEmpty && password.count >= 8
+    }
+
+    func login() async throws {
+        // Business logic here
+    }
+}
+
+struct LoginView: View {
+    @StateObject private var viewModel = LoginViewModel()
+
+    var body: some View {
+        Form {
+            TextField("Email", text: $viewModel.email)
+            SecureField("Password", text: $viewModel.password)
+            Button("Login") {
+                Task {
+                    try? await viewModel.login()
+                }
+            }
+            .disabled(!viewModel.isValid)
+        }
+    }
+}
+```
+
+```swift
+// Bad - logic embedded in view
+struct LoginView: View {
+    @State private var email = ""
+    @State private var password = ""
+    
+    var body: some View {
+        Form {
+            TextField("Email", text: $email)
+            SecureField("Password", text: $password)
+            Button("Login") {
+                // Business logic directly in view - hard to test
+                Task {
+                    if !email.isEmpty && password.count >= 8 {
+                        // Login logic...
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+**Note**: This is about separating business logic for testability, not about enforcing specific architectures like MVVM. The goal is to make logic testable while keeping views simple.
+
+## Action Handlers
+
+**Separate layout from logic.** View body should reference action methods, not contain logic.
+
+```swift
+// Good - action references method
+struct PublishView: View {
+    @State private var viewModel = PublishViewModel()
+    
+    var body: some View {
+        Button("Publish Project", action: viewModel.handlePublish)
+    }
+}
+
+// Avoid - logic in closure
+struct PublishView: View {
+    @State private var isLoading = false
+    @State private var showError = false
+    
+    var body: some View {
+        Button("Publish Project") {
+            isLoading = true
+            apiService.publish(project) { result in
+                if case .error = result {
+                    showError = true
+                }
+                isLoading = false
+            }
+        }
+    }
+}
+```
+
+**Why**: Separating logic from layout improves readability, testability, and maintainability.
+
+## Summary Checklist
+
+- [ ] Use relative layout over hard-coded constants
+- [ ] Views work in any context (don't assume screen size)
+- [ ] Custom views own static containers
+- [ ] Avoid deep view hierarchies (layout thrash)
+- [ ] Gate frequent geometry updates by thresholds
+- [ ] View logic separated into testable models/classes
+- [ ] Action handlers reference methods, not inline logic
+- [ ] Avoid excessive `GeometryReader` usage
+- [ ] Use `containerRelativeFrame()` when appropriate

--- a/.codex/skills/swiftui-expert-skill/references/liquid-glass.md
+++ b/.codex/skills/swiftui-expert-skill/references/liquid-glass.md
@@ -1,0 +1,377 @@
+# SwiftUI Liquid Glass Reference (iOS 26+)
+
+## Overview
+
+Liquid Glass is Apple's new design language introduced in iOS 26. It provides translucent, dynamic surfaces that respond to content and user interaction. This reference covers the native SwiftUI APIs for implementing Liquid Glass effects.
+
+## Availability
+
+All Liquid Glass APIs require iOS 26 or later. Always provide fallbacks:
+
+```swift
+if #available(iOS 26, *) {
+    // Liquid Glass implementation
+} else {
+    // Fallback using materials
+}
+```
+
+## Core APIs
+
+### glassEffect Modifier
+
+The primary modifier for applying glass effects to views:
+
+```swift
+.glassEffect(_ style: GlassEffectStyle = .regular, in shape: some Shape = .rect)
+```
+
+#### Basic Usage
+
+```swift
+Text("Hello")
+    .padding()
+    .glassEffect()  // Default regular style, rect shape
+```
+
+#### With Shape
+
+```swift
+Text("Rounded Glass")
+    .padding()
+    .glassEffect(in: .rect(cornerRadius: 16))
+
+Image(systemName: "star")
+    .padding()
+    .glassEffect(in: .circle)
+
+Text("Capsule")
+    .padding(.horizontal, 20)
+    .padding(.vertical, 10)
+    .glassEffect(in: .capsule)
+```
+
+### GlassEffectStyle
+
+#### Prominence Levels
+
+```swift
+.glassEffect(.regular)     // Standard glass appearance
+.glassEffect(.prominent)   // More visible, higher contrast
+```
+
+#### Tinting
+
+Add color tint to the glass:
+
+```swift
+.glassEffect(.regular.tint(.blue))
+.glassEffect(.prominent.tint(.red.opacity(0.3)))
+```
+
+#### Interactivity
+
+Make glass respond to touch/pointer hover:
+
+```swift
+// Interactive glass - responds to user interaction
+.glassEffect(.regular.interactive())
+
+// Combined with tint
+.glassEffect(.regular.tint(.blue).interactive())
+```
+
+**Important**: Only use `.interactive()` on elements that actually respond to user input (buttons, tappable views, focusable elements).
+
+## GlassEffectContainer
+
+Wraps multiple glass elements for proper visual grouping and spacing:
+
+```swift
+GlassEffectContainer {
+    HStack {
+        Button("One") { }
+            .glassEffect()
+        Button("Two") { }
+            .glassEffect()
+    }
+}
+```
+
+### With Spacing
+
+Control the visual spacing between glass elements:
+
+```swift
+GlassEffectContainer(spacing: 24) {
+    HStack(spacing: 24) {
+        GlassChip(icon: "pencil")
+        GlassChip(icon: "eraser")
+        GlassChip(icon: "trash")
+    }
+}
+```
+
+**Note**: The container's `spacing` parameter should match the actual spacing in your layout for proper glass effect rendering.
+
+## Glass Button Styles
+
+Built-in button styles for glass appearance:
+
+```swift
+// Standard glass button
+Button("Action") { }
+    .buttonStyle(.glass)
+
+// Prominent glass button (higher visibility)
+Button("Primary Action") { }
+    .buttonStyle(.glassProminent)
+```
+
+### Custom Glass Buttons
+
+For more control, apply glass effect manually:
+
+```swift
+Button(action: { }) {
+    Label("Settings", systemImage: "gear")
+        .padding()
+}
+.glassEffect(.regular.interactive(), in: .capsule)
+```
+
+## Morphing Transitions
+
+Create smooth transitions between glass elements using `glassEffectID` and `@Namespace`:
+
+```swift
+struct MorphingExample: View {
+    @Namespace private var animation
+    @State private var isExpanded = false
+
+    var body: some View {
+        GlassEffectContainer {
+            if isExpanded {
+                ExpandedCard()
+                    .glassEffect()
+                    .glassEffectID("card", in: animation)
+            } else {
+                CompactCard()
+                    .glassEffect()
+                    .glassEffectID("card", in: animation)
+            }
+        }
+        .animation(.smooth, value: isExpanded)
+    }
+}
+```
+
+### Requirements for Morphing
+
+1. Both views must have the same `glassEffectID`
+2. Use the same `@Namespace`
+3. Wrap in `GlassEffectContainer`
+4. Apply animation to the container or parent
+
+## Modifier Order
+
+**Critical**: Apply `glassEffect` after layout and visual modifiers:
+
+```swift
+// CORRECT order
+Text("Label")
+    .font(.headline)           // 1. Typography
+    .foregroundStyle(.primary) // 2. Color
+    .padding()                 // 3. Layout
+    .glassEffect()             // 4. Glass effect LAST
+
+// WRONG order - glass applied too early
+Text("Label")
+    .glassEffect()             // Wrong position
+    .padding()
+    .font(.headline)
+```
+
+## Complete Examples
+
+### Toolbar with Glass Buttons
+
+```swift
+struct GlassToolbar: View {
+    var body: some View {
+        if #available(iOS 26, *) {
+            GlassEffectContainer(spacing: 16) {
+                HStack(spacing: 16) {
+                    ToolbarButton(icon: "pencil", action: { })
+                    ToolbarButton(icon: "eraser", action: { })
+                    ToolbarButton(icon: "scissors", action: { })
+                    Spacer()
+                    ToolbarButton(icon: "square.and.arrow.up", action: { })
+                }
+                .padding(.horizontal)
+            }
+        } else {
+            // Fallback toolbar
+            HStack(spacing: 16) {
+                // ... fallback implementation
+            }
+        }
+    }
+}
+
+struct ToolbarButton: View {
+    let icon: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.title2)
+                .frame(width: 44, height: 44)
+        }
+        .glassEffect(.regular.interactive(), in: .circle)
+    }
+}
+```
+
+### Card with Glass Effect
+
+```swift
+struct GlassCard: View {
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        if #available(iOS 26, *) {
+            cardContent
+                .glassEffect(.regular, in: .rect(cornerRadius: 20))
+        } else {
+            cardContent
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20))
+        }
+    }
+
+    private var cardContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.headline)
+            Text(subtitle)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+```
+
+### Segmented Control
+
+```swift
+struct GlassSegmentedControl: View {
+    @Binding var selection: Int
+    let options: [String]
+    @Namespace private var animation
+
+    var body: some View {
+        if #available(iOS 26, *) {
+            GlassEffectContainer(spacing: 4) {
+                HStack(spacing: 4) {
+                    ForEach(options.indices, id: \.self) { index in
+                        Button(options[index]) {
+                            withAnimation(.smooth) {
+                                selection = index
+                            }
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .glassEffect(
+                            selection == index ? .prominent.interactive() : .regular.interactive(),
+                            in: .capsule
+                        )
+                        .glassEffectID(selection == index ? "selected" : "option\(index)", in: animation)
+                    }
+                }
+                .padding(4)
+            }
+        } else {
+            Picker("Options", selection: $selection) {
+                ForEach(options.indices, id: \.self) { index in
+                    Text(options[index]).tag(index)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+}
+```
+
+## Fallback Strategies
+
+### Using Materials
+
+```swift
+if #available(iOS 26, *) {
+    content.glassEffect()
+} else {
+    content.background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16))
+}
+```
+
+### Available Materials for Fallback
+
+- `.ultraThinMaterial` - Closest to glass appearance
+- `.thinMaterial` - Slightly more opaque
+- `.regularMaterial` - Standard blur
+- `.thickMaterial` - More opaque
+- `.ultraThickMaterial` - Most opaque
+
+### Conditional Modifier Extension
+
+```swift
+extension View {
+    @ViewBuilder
+    func glassEffectWithFallback(
+        _ style: GlassEffectStyle = .regular,
+        in shape: some Shape = .rect,
+        fallbackMaterial: Material = .ultraThinMaterial
+    ) -> some View {
+        if #available(iOS 26, *) {
+            self.glassEffect(style, in: shape)
+        } else {
+            self.background(fallbackMaterial, in: shape)
+        }
+    }
+}
+```
+
+## Best Practices
+
+### Do
+
+- Use `GlassEffectContainer` for grouped glass elements
+- Apply glass after layout modifiers
+- Use `.interactive()` only on tappable elements
+- Match container spacing with layout spacing
+- Provide material-based fallbacks for older iOS
+- Keep glass shapes consistent within a feature
+
+### Don't
+
+- Apply glass to every element (use sparingly)
+- Use `.interactive()` on static content
+- Mix different corner radii arbitrarily
+- Forget iOS version checks
+- Apply glass before padding/frame modifiers
+- Nest `GlassEffectContainer` unnecessarily
+
+## Checklist
+
+- [ ] `#available(iOS 26, *)` with fallback
+- [ ] `GlassEffectContainer` wraps grouped elements
+- [ ] `.glassEffect()` applied after layout modifiers
+- [ ] `.interactive()` only on user-interactable elements
+- [ ] `glassEffectID` with `@Namespace` for morphing
+- [ ] Consistent shapes and spacing across feature
+- [ ] Container spacing matches layout spacing
+- [ ] Appropriate prominence levels used

--- a/.codex/skills/swiftui-expert-skill/references/list-patterns.md
+++ b/.codex/skills/swiftui-expert-skill/references/list-patterns.md
@@ -1,0 +1,153 @@
+# SwiftUI List Patterns Reference
+
+## ForEach Identity and Stability
+
+**Always provide stable identity for `ForEach`.** Never use `.indices` for dynamic content.
+
+```swift
+// Good - stable identity via Identifiable
+extension User: Identifiable {
+    var id: String { userId }
+}
+
+ForEach(users) { user in
+    UserRow(user: user)
+}
+
+// Good - stable identity via keypath
+ForEach(users, id: \.userId) { user in
+    UserRow(user: user)
+}
+
+// Wrong - indices create static content
+ForEach(users.indices, id: \.self) { index in
+    UserRow(user: users[index])  // Can crash on removal!
+}
+
+// Wrong - unstable identity
+ForEach(users, id: \.self) { user in
+    UserRow(user: user)  // Only works if User is Hashable and stable
+}
+```
+
+**Critical**: Ensure **constant number of views per element** in `ForEach`:
+
+```swift
+// Good - consistent view count
+ForEach(items) { item in
+    ItemRow(item: item)
+}
+
+// Bad - variable view count breaks identity
+ForEach(items) { item in
+    if item.isSpecial {
+        SpecialRow(item: item)
+        DetailRow(item: item)
+    } else {
+        RegularRow(item: item)
+    }
+}
+```
+
+**Avoid inline filtering:**
+
+```swift
+// Bad - unstable identity, changes on every update
+ForEach(items.filter { $0.isEnabled }) { item in
+    ItemRow(item: item)
+}
+
+// Good - prefilter and cache
+@State private var enabledItems: [Item] = []
+
+var body: some View {
+    ForEach(enabledItems) { item in
+        ItemRow(item: item)
+    }
+    .onChange(of: items) { _, newItems in
+        enabledItems = newItems.filter { $0.isEnabled }
+    }
+}
+```
+
+**Avoid `AnyView` in list rows:**
+
+```swift
+// Bad - hides identity, increases cost
+ForEach(items) { item in
+    AnyView(item.isSpecial ? SpecialRow(item: item) : RegularRow(item: item))
+}
+
+// Good - Create a unified row view
+ForEach(items) { item in
+    ItemRow(item: item)
+}
+
+struct ItemRow: View {
+    let item: Item
+
+    var body: some View {
+        if item.isSpecial {
+            SpecialRow(item: item)
+        } else {
+            RegularRow(item: item)
+        }
+    }
+}
+```
+
+**Why**: Stable identity is critical for performance and animations. Unstable identity causes excessive diffing, broken animations, and potential crashes.
+
+## Enumerated Sequences
+
+**Always convert enumerated sequences to arrays. To be able to use them in a ForEach.**
+
+```swift
+let items = ["A", "B", "C"]
+
+// Correct
+ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+    Text("\(index): \(item)")
+}
+
+// Wrong - Doesn't compile, enumerated() isn't an array
+ForEach(items.enumerated(), id: \.offset) { index, item in
+    Text("\(index): \(item)")
+}
+```
+
+## List with Custom Styling
+
+```swift
+// Remove default background and separators
+List(items) { item in
+    ItemRow(item: item)
+        .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+        .listRowSeparator(.hidden)
+}
+.listStyle(.plain)
+.scrollContentBackground(.hidden)
+.background(Color.customBackground)
+.environment(\.defaultMinListRowHeight, 1)  // Allows custom row heights
+```
+
+## List with Pull-to-Refresh
+
+```swift
+List(items) { item in
+    ItemRow(item: item)
+}
+.refreshable {
+    await loadItems()
+}
+```
+
+## Summary Checklist
+
+- [ ] ForEach uses stable identity (never `.indices` for dynamic content)
+- [ ] Constant number of views per ForEach element
+- [ ] No inline filtering in ForEach (prefilter and cache instead)
+- [ ] No `AnyView` in list rows
+- [ ] Don't convert enumerated sequences to arrays
+- [ ] Use `.refreshable` for pull-to-refresh
+- [ ] Custom list styling uses appropriate modifiers

--- a/.codex/skills/swiftui-expert-skill/references/modern-apis.md
+++ b/.codex/skills/swiftui-expert-skill/references/modern-apis.md
@@ -1,0 +1,400 @@
+# Modern SwiftUI APIs Reference
+
+## Overview
+
+This reference covers modern SwiftUI API usage patterns and deprecated API replacements. Always use the latest APIs to ensure forward compatibility and access to new features.
+
+## Styling and Appearance
+
+### foregroundStyle() vs foregroundColor()
+
+**Always use `foregroundStyle()` instead of `foregroundColor()`.**
+
+```swift
+// Modern (Correct)
+Text("Hello")
+    .foregroundStyle(.primary)
+
+Image(systemName: "star")
+    .foregroundStyle(.blue)
+
+// Legacy (Avoid)
+Text("Hello")
+    .foregroundColor(.primary)
+```
+
+**Why**: `foregroundStyle()` supports hierarchical styles, gradients, and materials, making it more flexible and future-proof.
+
+### clipShape() vs cornerRadius()
+
+**Always use `clipShape(.rect(cornerRadius:))` instead of `cornerRadius()`.**
+
+```swift
+// Modern (Correct)
+Image("photo")
+    .clipShape(.rect(cornerRadius: 12))
+
+VStack {
+    // content
+}
+.clipShape(.rect(cornerRadius: 16))
+
+// Legacy (Avoid)
+Image("photo")
+    .cornerRadius(12)
+```
+
+**Why**: `cornerRadius()` is deprecated. `clipShape()` is more explicit and supports all shape types.
+
+### fontWeight() vs bold()
+
+**Don't apply `fontWeight()` unless there's a good reason. Always use `bold()` for bold text.**
+
+```swift
+// Correct
+Text("Important")
+    .bold()
+
+// Avoid (unless you need a specific weight)
+Text("Important")
+    .fontWeight(.bold)
+
+// Acceptable (specific weight needed)
+Text("Semibold")
+    .fontWeight(.semibold)
+```
+
+## Navigation
+
+### NavigationStack vs NavigationView
+
+**Always use `NavigationStack` instead of `NavigationView`.**
+
+```swift
+// Modern (Correct)
+NavigationStack {
+    List(items) { item in
+        NavigationLink(value: item) {
+            Text(item.name)
+        }
+    }
+    .navigationDestination(for: Item.self) { item in
+        DetailView(item: item)
+    }
+}
+
+// Legacy (Avoid)
+NavigationView {
+    List(items) { item in
+        NavigationLink(destination: DetailView(item: item)) {
+            Text(item.name)
+        }
+    }
+}
+```
+
+### navigationDestination(for:)
+
+**Use `navigationDestination(for:)` for type-safe navigation.**
+
+```swift
+struct ContentView: View {
+    var body: some View {
+        NavigationStack {
+            List {
+                NavigationLink("Profile", value: Route.profile)
+                NavigationLink("Settings", value: Route.settings)
+            }
+            .navigationDestination(for: Route.self) { route in
+                switch route {
+                case .profile:
+                    ProfileView()
+                case .settings:
+                    SettingsView()
+                }
+            }
+        }
+    }
+}
+
+enum Route: Hashable {
+    case profile
+    case settings
+}
+```
+
+## Tabs
+
+### Tab API vs tabItem()
+
+**For iOS 18 and later, prefer the `Tab` API over `tabItem()` to access modern tab features, and use availability checks or `tabItem()` for earlier OS versions.**
+
+```swift
+// Modern (Correct) - iOS 18+
+TabView {
+    Tab("Home", systemImage: "house") {
+        HomeView()
+    }
+    
+    Tab("Search", systemImage: "magnifyingglass") {
+        SearchView()
+    }
+    
+    Tab("Profile", systemImage: "person") {
+        ProfileView()
+    }
+}
+
+// Legacy (Avoid)
+TabView {
+    HomeView()
+        .tabItem {
+            Label("Home", systemImage: "house")
+        }
+}
+```
+
+**Important**: When using `Tab(role:)` with roles, you must use the new `Tab { } label: { }` syntax for all tabs. Mixing with `.tabItem()` causes compilation errors.
+
+```swift
+// Correct - all tabs use Tab syntax
+TabView {
+    Tab(role: .search) {
+        SearchView()
+    } label: {
+        Label("Search", systemImage: "magnifyingglass")
+    }
+    
+    Tab {
+        HomeView()
+    } label: {
+        Label("Home", systemImage: "house")
+    }
+}
+
+// Wrong - mixing Tab and tabItem causes errors
+TabView {
+    Tab(role: .search) {
+        SearchView()
+    } label: {
+        Label("Search", systemImage: "magnifyingglass")
+    }
+    
+    HomeView()  // Error: can't mix with Tab(role:)
+        .tabItem {
+            Label("Home", systemImage: "house")
+        }
+}
+```
+
+## Interactions
+
+### Button vs onTapGesture()
+
+**Never use `onTapGesture()` unless you specifically need tap location or tap count. Always use `Button` otherwise.**
+
+```swift
+// Correct - standard tap action
+Button("Tap me") {
+    performAction()
+}
+
+// Correct - need tap location
+Text("Tap anywhere")
+    .onTapGesture { location in
+        handleTap(at: location)
+    }
+
+// Correct - need tap count
+Image("photo")
+    .onTapGesture(count: 2) {
+        handleDoubleTap()
+    }
+
+// Wrong - use Button instead
+Text("Tap me")
+    .onTapGesture {
+        performAction()
+    }
+```
+
+**Why**: `Button` provides proper accessibility, visual feedback, and semantic meaning. Use `onTapGesture()` only when you need its specific features.
+
+### Button with Images
+
+**Always specify text alongside images in buttons for accessibility.**
+
+```swift
+// Correct - includes text label
+Button("Add Item", systemImage: "plus") {
+    addItem()
+}
+
+// Also correct - custom label
+Button {
+    addItem()
+} label: {
+    Label("Add Item", systemImage: "plus")
+}
+
+// Wrong - image only, no text
+Button {
+    addItem()
+} label: {
+    Image(systemName: "plus")
+}
+```
+
+## Layout and Sizing
+
+### Avoid UIScreen.main.bounds
+
+**Never use `UIScreen.main.bounds` to read available space.**
+
+```swift
+// Wrong - uses UIKit, doesn't respect safe areas
+let screenWidth = UIScreen.main.bounds.width
+
+// Correct - use GeometryReader
+GeometryReader { geometry in
+    Text("Width: \(geometry.size.width)")
+}
+
+// Better - use containerRelativeFrame (iOS 17+)
+Text("Full width")
+    .containerRelativeFrame(.horizontal)
+
+// Best - let SwiftUI handle sizing
+Text("Auto-sized")
+    .frame(maxWidth: .infinity)
+```
+
+### GeometryReader Alternatives
+
+> **iOS 17+**: `containerRelativeFrame` and `visualEffect` require iOS 17 or later.
+
+**Don't use `GeometryReader` if a newer alternative works.**
+
+```swift
+// Modern - containerRelativeFrame
+Image("hero")
+    .resizable()
+    .containerRelativeFrame(.horizontal) { length, axis in
+        length * 0.8
+    }
+
+// Modern - visualEffect for position-based effects
+Text("Parallax")
+    .visualEffect { content, geometry in
+        content.offset(y: geometry.frame(in: .global).minY * 0.5)
+    }
+
+// Legacy - only use if necessary
+GeometryReader { geometry in
+    Image("hero")
+        .frame(width: geometry.size.width * 0.8)
+}
+```
+
+## Type Erasure
+
+### Avoid AnyView
+
+**Avoid `AnyView` unless absolutely required.**
+
+```swift
+// Prefer - use @ViewBuilder
+@ViewBuilder
+func content() -> some View {
+    if condition {
+        Text("Option A")
+    } else {
+        Image(systemName: "photo")
+    }
+}
+
+// Avoid - type erasure has performance cost
+func content() -> AnyView {
+    if condition {
+        return AnyView(Text("Option A"))
+    } else {
+        return AnyView(Image(systemName: "photo"))
+    }
+}
+
+// Acceptable - when protocol conformance requires it
+var body: some View {
+    // Complex conditional logic that requires type erasure
+}
+```
+
+## Styling Best Practices
+
+### Dynamic Type
+
+**Don't force specific font sizes. Prefer Dynamic Type.**
+
+```swift
+// Correct - respects user's text size preferences
+Text("Title")
+    .font(.title)
+
+Text("Body")
+    .font(.body)
+
+// Avoid - fixed size doesn't scale
+Text("Title")
+    .font(.system(size: 24))
+```
+
+### UIKit Colors
+
+**Avoid using UIKit colors in SwiftUI code.**
+
+```swift
+// Correct - SwiftUI colors
+Text("Hello")
+    .foregroundStyle(.blue)
+    .background(.gray.opacity(0.2))
+
+// Wrong - UIKit colors
+Text("Hello")
+    .foregroundColor(Color(UIColor.systemBlue))
+    .background(Color(UIColor.systemGray))
+```
+
+## Static Member Lookup
+
+**Prefer static member lookup to struct instances.**
+
+```swift
+// Correct - static member lookup
+Circle()
+    .fill(.blue)
+Button("Action") { }
+    .buttonStyle(.borderedProminent)
+
+// Verbose - unnecessary struct instantiation
+Circle()
+    .fill(Color.blue)
+Button("Action") { }
+    .buttonStyle(BorderedProminentButtonStyle())
+```
+
+## Summary Checklist
+
+- [ ] Use `foregroundStyle()` instead of `foregroundColor()`
+- [ ] Use `clipShape(.rect(cornerRadius:))` instead of `cornerRadius()`
+- [ ] Use `Tab` API instead of `tabItem()`
+- [ ] Use `Button` instead of `onTapGesture()` (unless need location/count)
+- [ ] Use `NavigationStack` instead of `NavigationView`
+- [ ] Use `navigationDestination(for:)` for type-safe navigation
+- [ ] Avoid `AnyView` unless required
+- [ ] Avoid `UIScreen.main.bounds`
+- [ ] Avoid `GeometryReader` when alternatives exist
+- [ ] Use Dynamic Type instead of fixed font sizes
+- [ ] Avoid hard-coded padding/spacing unless requested
+- [ ] Avoid UIKit colors in SwiftUI
+- [ ] Use static member lookup (`.blue` vs `Color.blue`)
+- [ ] Include text labels with button images
+- [ ] Use `bold()` instead of `fontWeight(.bold)`

--- a/.codex/skills/swiftui-expert-skill/references/performance-patterns.md
+++ b/.codex/skills/swiftui-expert-skill/references/performance-patterns.md
@@ -1,0 +1,377 @@
+# SwiftUI Performance Patterns Reference
+
+## Performance Optimization
+
+### 1. Avoid Redundant State Updates
+
+SwiftUI doesn't compare values before triggering updates:
+
+```swift
+// BAD - triggers update even if value unchanged
+.onReceive(publisher) { value in
+    self.currentValue = value  // Always triggers body re-evaluation
+}
+
+// GOOD - only update when different
+.onReceive(publisher) { value in
+    if self.currentValue != value {
+        self.currentValue = value
+    }
+}
+```
+
+### 2. Optimize Hot Paths
+
+Hot paths are frequently executed code (scroll handlers, animations, gestures):
+
+```swift
+// BAD - updates state on every scroll position change
+.onPreferenceChange(ScrollOffsetKey.self) { offset in
+    shouldShowTitle = offset.y <= -32  // Fires constantly during scroll!
+}
+
+// GOOD - only update when threshold crossed
+.onPreferenceChange(ScrollOffsetKey.self) { offset in
+    let shouldShow = offset.y <= -32
+    if shouldShow != shouldShowTitle {
+        shouldShowTitle = shouldShow  // Fires only when crossing threshold
+    }
+}
+```
+
+### 3. Pass Only What Views Need
+
+**Avoid passing large "config" or "context" objects.** Pass only the specific values each view needs.
+
+```swift
+// Good - pass specific values
+@Observable
+@MainActor
+final class AppConfig {
+    var theme: Theme
+    var fontSize: CGFloat
+    var notifications: Bool
+}
+
+struct SettingsView: View {
+    @State private var config = AppConfig()
+    
+    var body: some View {
+        VStack {
+            ThemeSelector(theme: config.theme)
+            FontSizeSlider(fontSize: config.fontSize)
+        }
+    }
+}
+
+// Avoid - passing entire config
+struct SettingsView: View {
+    @State private var config = AppConfig()
+    
+    var body: some View {
+        VStack {
+            ThemeSelector(config: config)  // Gets notified of ALL config changes
+            FontSizeSlider(config: config)  // Gets notified of ALL config changes
+        }
+    }
+}
+```
+
+**Why**: When using `ObservableObject`, any `@Published` property change triggers updates in all views observing the object. With `@Observable`, views update when properties they access change, but passing entire objects still creates unnecessary dependencies.
+
+### 4. Use Equatable Views
+
+For views with expensive bodies, conform to `Equatable`:
+
+```swift
+struct ExpensiveView: View, Equatable {
+    let data: SomeData
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.data.id == rhs.data.id  // Custom equality check
+    }
+
+    var body: some View {
+        // Expensive computation
+    }
+}
+
+// Usage
+ExpensiveView(data: data)
+    .equatable()  // Use custom equality
+```
+
+**Caution**: If you add new state or dependencies to your view, remember to update your `==` function!
+
+### 5. POD Views for Fast Diffing
+
+**POD (Plain Old Data) views use `memcmp` for fastest diffing.** A view is POD if it only contains simple value types and no property wrappers.
+
+```swift
+// POD view - fastest diffing
+struct FastView: View {
+    let title: String
+    let count: Int
+    
+    var body: some View {
+        Text("\(title): \(count)")
+    }
+}
+
+// Non-POD view - uses reflection or custom equality
+struct SlowerView: View {
+    let title: String
+    @State private var isExpanded = false  // Property wrapper makes it non-POD
+    
+    var body: some View {
+        Text(title)
+    }
+}
+```
+
+**Advanced Pattern**: Wrap expensive non-POD views in POD parent views:
+
+```swift
+// POD wrapper for fast diffing
+struct ExpensiveView: View {
+    let value: Int
+    
+    var body: some View {
+        ExpensiveViewInternal(value: value)
+    }
+}
+
+// Internal view with state
+private struct ExpensiveViewInternal: View {
+    let value: Int
+    @State private var item: Item?
+    
+    var body: some View {
+        // Expensive rendering
+    }
+}
+```
+
+**Why**: The POD parent uses fast `memcmp` comparison. Only when `value` changes does the internal view get diffed.
+
+### 6. Lazy Loading
+
+Use lazy containers for large collections:
+
+```swift
+// BAD - creates all views immediately
+ScrollView {
+    VStack {
+        ForEach(items) { item in
+            ExpensiveRow(item: item)
+        }
+    }
+}
+
+// GOOD - creates views on demand
+ScrollView {
+    LazyVStack {
+        ForEach(items) { item in
+            ExpensiveRow(item: item)
+        }
+    }
+}
+```
+
+### 7. Task Cancellation
+
+Cancel async work when view disappears:
+
+```swift
+struct DataView: View {
+    @State private var data: [Item] = []
+
+    var body: some View {
+        List(data) { item in
+            Text(item.name)
+        }
+        .task {
+            // Automatically cancelled when view disappears
+            data = await fetchData()
+        }
+    }
+}
+```
+
+### 8. Debug View Updates
+
+**Use `Self._printChanges()` to debug unexpected view updates.**
+
+```swift
+struct DebugView: View {
+    @State private var count = 0
+    @State private var name = ""
+    
+    var body: some View {
+        let _ = Self._printChanges()  // Prints what caused body to be called
+        
+        VStack {
+            Text("Count: \(count)")
+            Text("Name: \(name)")
+        }
+    }
+}
+```
+
+**Why**: This helps identify which state changes are causing view updates. Even if a parent updates, a child's body shouldn't be called if the child's dependencies didn't change.
+
+### 9. Eliminate Unnecessary Dependencies
+
+**Narrow state scope to reduce update fan-out.**
+
+```swift
+// Bad - broad dependency
+@Observable
+@MainActor
+final class AppModel {
+    var items: [Item] = []
+    var settings: Settings = .init()
+    var theme: Theme = .light
+}
+
+struct ItemRow: View {
+    @Environment(AppModel.self) private var model
+    let item: Item
+    
+    var body: some View {
+        // Updates when ANY property of model changes
+        Text(item.name)
+            .foregroundStyle(model.theme.primaryColor)
+    }
+}
+
+// Good - narrow dependency
+struct ItemRow: View {
+    let item: Item
+    let themeColor: Color  // Only depends on what it needs
+    
+    var body: some View {
+        Text(item.name)
+            .foregroundStyle(themeColor)
+    }
+}
+```
+
+**Why**: With `ObservableObject`, any `@Published` property change triggers all observers. With `@Observable`, views update when accessed properties change, but passing entire models still creates broader dependencies than necessary.
+
+### 10. Common Performance Issues
+
+**Be aware of common performance bottlenecks in SwiftUI:**
+
+- View invalidation storms from broad state changes
+- Unstable identity in lists causing excessive diffing
+- Heavy work in `body` (formatting, sorting, image decoding)
+- Layout thrash from deep stacks or preference chains
+
+**When performance issues arise**, suggest the user profile with Instruments (SwiftUI template) to identify specific bottlenecks.
+
+## Anti-Patterns
+
+### 1. Creating Objects in Body
+
+```swift
+// BAD - creates new formatter every body call
+var body: some View {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .long
+    return Text(formatter.string(from: date))
+}
+
+// GOOD - static or stored formatter
+private static let dateFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.dateStyle = .long
+    return f
+}()
+
+var body: some View {
+    Text(Self.dateFormatter.string(from: date))
+}
+```
+
+### 2. Heavy Computation in Body
+
+**Keep view body simple and pure.** Avoid side effects, dispatching, or complex logic.
+
+```swift
+// BAD - sorts array every body call
+var body: some View {
+    List(items.sorted { $0.name < $1.name }) { item in
+        Text(item.name)
+    }
+}
+
+// GOOD - compute once, store result
+@State private var sortedItems: [Item] = []
+
+var body: some View {
+    List(sortedItems) { item in
+        Text(item.name)
+    }
+    .onChange(of: items) { _, newItems in
+        sortedItems = newItems.sorted { $0.name < $1.name }
+    }
+}
+
+// Better - compute in model
+@Observable
+@MainActor
+final class ItemsViewModel {
+    var items: [Item] = []
+    
+    var sortedItems: [Item] {
+        items.sorted { $0.name < $1.name }
+    }
+    
+    func loadItems() async {
+        items = await fetchItems()
+    }
+}
+
+struct ItemsView: View {
+    @State private var viewModel = ItemsViewModel()
+    
+    var body: some View {
+        List(viewModel.sortedItems) { item in
+            Text(item.name)
+        }
+        .task {
+            await viewModel.loadItems()
+        }
+    }
+}
+```
+
+**Why**: Complex logic in `body` slows down view updates and can cause frame drops. The `body` should be a pure structural representation of state.
+
+### 3. Unnecessary State
+
+```swift
+// BAD - derived state stored separately
+@State private var items: [Item] = []
+@State private var itemCount: Int = 0  // Unnecessary!
+
+// GOOD - compute derived values
+@State private var items: [Item] = []
+
+var itemCount: Int { items.count }  // Computed property
+```
+
+## Summary Checklist
+
+- [ ] State updates check for value changes before assigning
+- [ ] Hot paths minimize state updates
+- [ ] Pass only needed values to views (avoid large config objects)
+- [ ] Large lists use `LazyVStack`/`LazyHStack`
+- [ ] No object creation in `body`
+- [ ] Heavy computation moved out of `body`
+- [ ] Body kept simple and pure (no side effects)
+- [ ] Derived state computed, not stored
+- [ ] Use `Self._printChanges()` to debug unexpected updates
+- [ ] Equatable conformance for expensive views (when appropriate)
+- [ ] Consider POD view wrappers for advanced optimization

--- a/.codex/skills/swiftui-expert-skill/references/scroll-patterns.md
+++ b/.codex/skills/swiftui-expert-skill/references/scroll-patterns.md
@@ -1,0 +1,305 @@
+# SwiftUI ScrollView Patterns Reference
+
+## ScrollView Modifiers
+
+### Hiding Scroll Indicators
+
+**Use `.scrollIndicators(.hidden)` modifier instead of initializer parameter.**
+
+```swift
+// Modern (Correct)
+ScrollView {
+    content
+}
+.scrollIndicators(.hidden)
+
+// Legacy (Avoid)
+ScrollView(showsIndicators: false) {
+    content
+}
+```
+
+## ScrollViewReader for Programmatic Scrolling
+
+**Use `ScrollViewReader` for scroll-to-top, scroll-to-bottom, and anchor-based jumps.**
+
+```swift
+struct ChatView: View {
+    @State private var messages: [Message] = []
+    private let bottomID = "bottom"
+    
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack {
+                    ForEach(messages) { message in
+                        MessageRow(message: message)
+                            .id(message.id)
+                    }
+                    Color.clear
+                        .frame(height: 1)
+                        .id(bottomID)
+                }
+            }
+            .onChange(of: messages.count) { _, _ in
+                withAnimation {
+                    proxy.scrollTo(bottomID, anchor: .bottom)
+                }
+            }
+            .onAppear {
+                proxy.scrollTo(bottomID, anchor: .bottom)
+            }
+        }
+    }
+}
+```
+
+### Scroll-to-Top Pattern
+
+```swift
+struct FeedView: View {
+    @State private var items: [Item] = []
+    @State private var scrollToTop = false
+    private let topID = "top"
+    
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack {
+                    Color.clear
+                        .frame(height: 1)
+                        .id(topID)
+                    
+                    ForEach(items) { item in
+                        ItemRow(item: item)
+                    }
+                }
+            }
+            .onChange(of: scrollToTop) { _, shouldScroll in
+                if shouldScroll {
+                    withAnimation {
+                        proxy.scrollTo(topID, anchor: .top)
+                    }
+                    scrollToTop = false
+                }
+            }
+        }
+    }
+}
+```
+
+**Why**: `ScrollViewReader` provides programmatic scroll control with stable anchors. Always use stable IDs and explicit animations.
+
+## Scroll Position Tracking
+
+### Basic Scroll Position
+
+**Avoid** - Storing scroll position directly triggers view updates on every scroll frame:
+
+```swift
+// ❌ Bad Practice - causes unnecessary re-renders
+struct ContentView: View {
+    @State private var scrollPosition: CGFloat = 0
+
+    var body: some View {
+        ScrollView {
+            content
+                .background(
+                    GeometryReader { geometry in
+                        Color.clear
+                            .preference(
+                                key: ScrollOffsetPreferenceKey.self,
+                                value: geometry.frame(in: .named("scroll")).minY
+                            )
+                    }
+                )
+        }
+        .coordinateSpace(name: "scroll")
+        .onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
+            scrollPosition = value
+        }
+    }
+}
+```
+
+**Preferred** - Check scroll position and update a flag based on thresholds for smoother, more efficient scrolling:
+
+```swift
+// ✅ Good Practice - only updates state when crossing threshold
+struct ContentView: View {
+    @State private var startAnimation: Bool = false
+
+    var body: some View {
+        ScrollView {
+            content
+                .background(
+                    GeometryReader { geometry in
+                        Color.clear
+                            .preference(
+                                key: ScrollOffsetPreferenceKey.self,
+                                value: geometry.frame(in: .named("scroll")).minY
+                            )
+                    }
+                )
+        }
+        .coordinateSpace(name: "scroll")
+        .onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
+            if value < -100 {
+                startAnimation = true
+            } else {
+                startAnimation = false
+            }
+        }
+    }
+}
+
+struct ScrollOffsetPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+```
+
+### Scroll-Based Header Visibility
+
+```swift
+struct ContentView: View {
+    @State private var showHeader = true
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            if showHeader {
+                HeaderView()
+                    .transition(.move(edge: .top))
+            }
+            
+            ScrollView {
+                content
+                    .background(
+                        GeometryReader { geometry in
+                            Color.clear
+                                .preference(
+                                    key: ScrollOffsetPreferenceKey.self,
+                                    value: geometry.frame(in: .named("scroll")).minY
+                                )
+                        }
+                    )
+            }
+            .coordinateSpace(name: "scroll")
+            .onPreferenceChange(ScrollOffsetPreferenceKey.self) { offset in
+                if offset < -50 { // Scrolling down
+                   withAnimation { showHeader = false }
+                } else if offset > 50 { // Scrolling up
+                  withAnimation { showHeader = true }
+                }
+            }
+        }
+    }
+}
+```
+
+## Scroll Transitions and Effects
+
+> **iOS 17+**: All APIs in this section require iOS 17 or later.
+
+### Scroll-Based Opacity
+
+```swift
+struct ParallaxView: View {
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 20) {
+                ForEach(items) { item in
+                    ItemCard(item: item)
+                        .visualEffect { content, geometry in
+                            let frame = geometry.frame(in: .scrollView)
+                            let distance = min(0, frame.minY)
+                            return content
+                                .opacity(1 + distance / 200)
+                        }
+                }
+            }
+        }
+    }
+}
+```
+
+### Parallax Effect
+
+```swift
+struct ParallaxHeader: View {
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 0) {
+                Image("hero")
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(height: 300)
+                    .visualEffect { content, geometry in
+                        let offset = geometry.frame(in: .scrollView).minY
+                        return content
+                            .offset(y: offset > 0 ? -offset * 0.5 : 0)
+                    }
+                    .clipped()
+                
+                ContentView()
+            }
+        }
+    }
+}
+```
+
+## Scroll Target Behavior
+
+> **iOS 17+**: All APIs in this section require iOS 17 or later.
+
+### Paging ScrollView
+
+```swift
+struct PagingView: View {
+    var body: some View {
+        ScrollView(.horizontal) {
+            LazyHStack(spacing: 0) {
+                ForEach(pages) { page in
+                    PageView(page: page)
+                        .containerRelativeFrame(.horizontal)
+                }
+            }
+            .scrollTargetLayout()
+        }
+        .scrollTargetBehavior(.paging)
+    }
+}
+```
+
+### Snap to Items
+
+```swift
+struct SnapScrollView: View {
+    var body: some View {
+        ScrollView(.horizontal) {
+            LazyHStack(spacing: 16) {
+                ForEach(items) { item in
+                    ItemCard(item: item)
+                        .frame(width: 280)
+                }
+            }
+            .scrollTargetLayout()
+        }
+        .scrollTargetBehavior(.viewAligned)
+        .contentMargins(.horizontal, 20)
+    }
+}
+```
+
+## Summary Checklist
+
+- [ ] Use `.scrollIndicators(.hidden)` instead of initializer parameter
+- [ ] Use `ScrollViewReader` with stable IDs for programmatic scrolling
+- [ ] Always use explicit animations with `scrollTo()`
+- [ ] Use `.visualEffect` for scroll-based visual changes
+- [ ] Use `.scrollTargetBehavior(.paging)` for paging behavior
+- [ ] Use `.scrollTargetBehavior(.viewAligned)` for snap-to-item behavior
+- [ ] Gate frequent scroll position updates by thresholds
+- [ ] Use preference keys for custom scroll position tracking

--- a/.codex/skills/swiftui-expert-skill/references/sheet-navigation-patterns.md
+++ b/.codex/skills/swiftui-expert-skill/references/sheet-navigation-patterns.md
@@ -1,0 +1,292 @@
+# SwiftUI Sheet and Navigation Patterns Reference
+
+## Sheet Patterns
+
+### Item-Driven Sheets (Preferred)
+
+**Use `.sheet(item:)` instead of `.sheet(isPresented:)` when presenting model-based content.**
+
+```swift
+// Good - item-driven
+@State private var selectedItem: Item?
+
+var body: some View {
+    List(items) { item in
+        Button(item.name) {
+            selectedItem = item
+        }
+    }
+    .sheet(item: $selectedItem) { item in
+        ItemDetailSheet(item: item)
+    }
+}
+
+// Avoid - boolean flag requires separate state
+@State private var showSheet = false
+@State private var selectedItem: Item?
+
+var body: some View {
+    List(items) { item in
+        Button(item.name) {
+            selectedItem = item
+            showSheet = true
+        }
+    }
+    .sheet(isPresented: $showSheet) {
+        if let selectedItem {
+            ItemDetailSheet(item: selectedItem)
+        }
+    }
+}
+```
+
+**Why**: `.sheet(item:)` automatically handles presentation state and avoids optional unwrapping in the sheet body.
+
+### Sheets Own Their Actions
+
+**Sheets should handle their own dismiss and actions internally.**
+
+```swift
+// Good - sheet owns its actions
+struct EditItemSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(DataStore.self) private var store
+    
+    let item: Item
+    @State private var name: String
+    @State private var isSaving = false
+    
+    init(item: Item) {
+        self.item = item
+        _name = State(initialValue: item.name)
+    }
+    
+    var body: some View {
+        NavigationStack {
+            Form {
+                TextField("Name", text: $name)
+            }
+            .navigationTitle("Edit Item")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(isSaving ? "Saving..." : "Save") {
+                        Task { await save() }
+                    }
+                    .disabled(isSaving || name.isEmpty)
+                }
+            }
+        }
+    }
+    
+    private func save() async {
+        isSaving = true
+        await store.updateItem(item, name: name)
+        dismiss()
+    }
+}
+
+// Avoid - parent manages sheet actions via closures
+struct ParentView: View {
+    @State private var selectedItem: Item?
+    
+    var body: some View {
+        List(items) { item in
+            Button(item.name) {
+                selectedItem = item
+            }
+        }
+        .sheet(item: $selectedItem) { item in
+            EditItemSheet(
+                item: item,
+                onSave: { newName in
+                    // Parent handles save
+                },
+                onCancel: {
+                    selectedItem = nil
+                }
+            )
+        }
+    }
+}
+```
+
+**Why**: Sheets that own their actions are more reusable and don't require callback prop-drilling.
+
+## Navigation Patterns
+
+### Type-Safe Navigation with NavigationStack
+
+```swift
+struct ContentView: View {
+    var body: some View {
+        NavigationStack {
+            List {
+                NavigationLink("Profile", value: Route.profile)
+                NavigationLink("Settings", value: Route.settings)
+            }
+            .navigationDestination(for: Route.self) { route in
+                switch route {
+                case .profile:
+                    ProfileView()
+                case .settings:
+                    SettingsView()
+                }
+            }
+        }
+    }
+}
+
+enum Route: Hashable {
+    case profile
+    case settings
+}
+```
+
+### Programmatic Navigation
+
+```swift
+struct ContentView: View {
+    @State private var navigationPath = NavigationPath()
+    
+    var body: some View {
+        NavigationStack(path: $navigationPath) {
+            List {
+                Button("Go to Detail") {
+                    navigationPath.append(DetailRoute.item(id: 1))
+                }
+            }
+            .navigationDestination(for: DetailRoute.self) { route in
+                switch route {
+                case .item(let id):
+                    ItemDetailView(id: id)
+                }
+            }
+        }
+    }
+}
+
+enum DetailRoute: Hashable {
+    case item(id: Int)
+}
+```
+
+### Navigation with State Restoration
+
+```swift
+struct ContentView: View {
+    @State private var navigationPath = NavigationPath()
+    
+    var body: some View {
+        NavigationStack(path: $navigationPath) {
+            RootView()
+                .navigationDestination(for: Route.self) { route in
+                    destinationView(for: route)
+                }
+        }
+    }
+    
+    @ViewBuilder
+    private func destinationView(for route: Route) -> some View {
+        switch route {
+        case .profile:
+            ProfileView()
+        case .settings:
+            SettingsView()
+        }
+    }
+}
+```
+
+## Presentation Modifiers
+
+### Full Screen Cover
+
+```swift
+struct ContentView: View {
+    @State private var showFullScreen = false
+    
+    var body: some View {
+        Button("Show Full Screen") {
+            showFullScreen = true
+        }
+        .fullScreenCover(isPresented: $showFullScreen) {
+            FullScreenView()
+        }
+    }
+}
+```
+
+### Popover
+
+```swift
+struct ContentView: View {
+    @State private var showPopover = false
+    
+    var body: some View {
+        Button("Show Popover") {
+            showPopover = true
+        }
+        .popover(isPresented: $showPopover) {
+            PopoverContentView()
+                .presentationCompactAdaptation(.popover)  // Don't adapt to sheet on iPhone
+        }
+    }
+}
+```
+
+### Alert with Actions
+
+```swift
+struct ContentView: View {
+    @State private var showAlert = false
+    
+    var body: some View {
+        Button("Show Alert") {
+            showAlert = true
+        }
+        .alert("Delete Item?", isPresented: $showAlert) {
+            Button("Delete", role: .destructive) {
+                deleteItem()
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("This action cannot be undone.")
+        }
+    }
+}
+```
+
+### Confirmation Dialog
+
+```swift
+struct ContentView: View {
+    @State private var showDialog = false
+    
+    var body: some View {
+        Button("Show Options") {
+            showDialog = true
+        }
+        .confirmationDialog("Choose an option", isPresented: $showDialog) {
+            Button("Option 1") { handleOption1() }
+            Button("Option 2") { handleOption2() }
+            Button("Cancel", role: .cancel) { }
+        }
+    }
+}
+```
+
+## Summary Checklist
+
+- [ ] Use `.sheet(item:)` for model-based sheets
+- [ ] Sheets own their actions and dismiss internally
+- [ ] Use `NavigationStack` with `navigationDestination(for:)` for type-safe navigation
+- [ ] Use `NavigationPath` for programmatic navigation
+- [ ] Use appropriate presentation modifiers (sheet, fullScreenCover, popover)
+- [ ] Alerts and confirmation dialogs use modern API with actions
+- [ ] Avoid passing dismiss/save callbacks to sheets
+- [ ] Navigation state can be saved/restored when needed

--- a/.codex/skills/swiftui-expert-skill/references/state-management.md
+++ b/.codex/skills/swiftui-expert-skill/references/state-management.md
@@ -1,0 +1,447 @@
+# SwiftUI State Management Reference
+
+## Property Wrapper Selection Guide
+
+| Wrapper | Use When | Notes |
+|---------|----------|-------|
+| `@State` | Internal view state that triggers updates | Must be `private` |
+| `@Binding` | Child view needs to modify parent's state | Don't use for read-only |
+| `@Bindable` | iOS 17+: View receives `@Observable` object and needs bindings | For injected observables |
+| `let` | Read-only value passed from parent | Simplest option |
+| `var` | Read-only value that child observes via `.onChange()` | For reactive reads |
+
+**Legacy (Pre-iOS 17):**
+| Wrapper | Use When | Notes |
+|---------|----------|-------|
+| `@StateObject` | View owns an `ObservableObject` instance | Use `@State` with `@Observable` instead |
+| `@ObservedObject` | View receives an `ObservableObject` from outside | Never create inline |
+
+## @State
+
+Always mark `@State` properties as `private`. Use for internal view state that triggers UI updates.
+
+```swift
+// Correct
+@State private var isAnimating = false
+@State private var selectedTab = 0
+```
+
+**Why Private?** Marking state as `private` makes it clear what's created by the view versus what's passed in. It also prevents accidentally passing initial values that will be ignored (see "Don't Pass Values as @State" below).
+
+### iOS 17+ with @Observable (Preferred)
+
+**Always prefer `@Observable` over `ObservableObject`.** With iOS 17's `@Observable` macro, use `@State` instead of `@StateObject`:
+
+```swift
+@Observable
+@MainActor  // Always mark @Observable classes with @MainActor
+final class DataModel {
+    var name = "Some Name"
+    var count = 0
+}
+
+struct MyView: View {
+    @State private var model = DataModel()  // Use @State, not @StateObject
+
+    var body: some View {
+        VStack {
+            TextField("Name", text: $model.name)
+            Stepper("Count: \(model.count)", value: $model.count)
+        }
+    }
+}
+```
+
+**Note**: You may want to mark `@Observable` classes with `@MainActor` to ensure thread safety with SwiftUI, unless your project or package uses Default Actor Isolation set to `MainActor`—in which case, the explicit attribute is redundant and can be omitted.
+
+## @Binding
+
+Use only when child view needs to **modify** parent's state. If child only reads the value, use `let` instead.
+
+```swift
+// Parent
+struct ParentView: View {
+    @State private var isSelected = false
+
+    var body: some View {
+        ChildView(isSelected: $isSelected)
+    }
+}
+
+// Child - will modify the value
+struct ChildView: View {
+    @Binding var isSelected: Bool
+
+    var body: some View {
+        Button("Toggle") {
+            isSelected.toggle()
+        }
+    }
+}
+```
+
+### When NOT to use @Binding
+
+```swift
+// Bad - child only displays, doesn't modify
+struct DisplayView: View {
+    @Binding var title: String  // Unnecessary
+    var body: some View {
+        Text(title)
+    }
+}
+
+// Good - use let for read-only
+struct DisplayView: View {
+    let title: String
+    var body: some View {
+        Text(title)
+    }
+}
+```
+
+## @StateObject vs @ObservedObject (Legacy - Pre-iOS 17)
+
+**Note**: These are legacy patterns. Always prefer `@Observable` with `@State` for iOS 17+.
+
+The key distinction is **ownership**:
+
+- `@StateObject`: View **creates and owns** the object
+- `@ObservedObject`: View **receives** the object from outside
+
+```swift
+// Legacy pattern - use @Observable instead
+class MyViewModel: ObservableObject {
+    @Published var items: [String] = []
+}
+
+// View creates it → @StateObject
+struct OwnerView: View {
+    @StateObject private var viewModel = MyViewModel()
+
+    var body: some View {
+        ChildView(viewModel: viewModel)
+    }
+}
+
+// View receives it → @ObservedObject
+struct ChildView: View {
+    @ObservedObject var viewModel: MyViewModel
+
+    var body: some View {
+        List(viewModel.items, id: \.self) { Text($0) }
+    }
+}
+```
+
+### Common Mistake
+
+Never create an `ObservableObject` inline with `@ObservedObject`:
+
+```swift
+// WRONG - creates new instance on every view update
+struct BadView: View {
+    @ObservedObject var viewModel = MyViewModel()  // BUG!
+}
+
+// CORRECT - owned objects use @StateObject
+struct GoodView: View {
+    @StateObject private var viewModel = MyViewModel()
+}
+```
+
+### @StateObject instantiation in View's initializer
+If you need to create a @StateObject with initialization parameters in your view's custom initializer, be aware of redundant allocations and hidden side effects.
+
+```swift
+// WRONG - creates a new ViewModel instance each time the view's initializer is called
+// (which can happen multiple times during SwiftUI's structural identity evaluation)
+struct MovieDetailsView: View {
+    
+    @StateObject private var viewModel: MovieDetailsViewModel
+    
+    init(movie: Movie) {
+        let viewModel = MovieDetailsViewModel(movie: movie)
+        _viewModel = StateObject(wrappedValue: viewModel)      
+    }
+    
+    var body: some View {
+        // ...
+    }
+}
+
+// CORRECT - creation in @autoclosure prevents multiple instantiations
+struct MovieDetailsView: View {
+    
+    @StateObject private var viewModel: MovieDetailsViewModel
+    
+    init(movie: Movie) {
+        _viewModel = StateObject(
+            wrappedValue: MovieDetailsViewModel(movie: movie)
+        )      
+    }
+    
+    var body: some View {
+        // ...
+    }
+}
+```
+
+**Modern Alternative**: Use `@Observable` with `@State` instead of `ObservableObject` patterns.
+
+## Don't Pass Values as @State
+
+**Critical**: Never declare passed values as `@State` or `@StateObject`. The value you provide is only an initial value and won't update.
+
+```swift
+// Parent
+struct ParentView: View {
+    @State private var item = Item(name: "Original")
+    
+    var body: some View {
+        ChildView(item: item)
+        Button("Change") {
+            item.name = "Updated"  // Child won't see this!
+        }
+    }
+}
+
+// Wrong - child ignores updates from parent
+struct ChildView: View {
+    @State var item: Item  // Accepts initial value only!
+    
+    var body: some View {
+        Text(item.name)  // Shows "Original" forever
+    }
+}
+
+// Correct - child receives updates
+struct ChildView: View {
+    let item: Item  // Or @Binding if child needs to modify
+    
+    var body: some View {
+        Text(item.name)  // Updates when parent changes
+    }
+}
+```
+
+**Why**: `@State` and `@StateObject` retain values between view updates. That's their purpose. When a parent passes a new value, the child reuses its existing state.
+
+**Prevention**: Always mark `@State` and `@StateObject` as `private`. This prevents them from appearing in the generated initializer.
+
+## @Bindable (iOS 17+)
+
+Use when receiving an `@Observable` object from outside and needing bindings:
+
+```swift
+@Observable
+final class UserModel {
+    var name = ""
+    var email = ""
+}
+
+struct ParentView: View {
+    @State private var user = UserModel()
+
+    var body: some View {
+        EditUserView(user: user)
+    }
+}
+
+struct EditUserView: View {
+    @Bindable var user: UserModel  // Received from parent, needs bindings
+
+    var body: some View {
+        Form {
+            TextField("Name", text: $user.name)
+            TextField("Email", text: $user.email)
+        }
+    }
+}
+```
+
+## let vs var for Passed Values
+
+### Use `let` for read-only display
+
+```swift
+struct ProfileHeader: View {
+    let username: String
+    let avatarURL: URL
+
+    var body: some View {
+        HStack {
+            AsyncImage(url: avatarURL)
+            Text(username)
+        }
+    }
+}
+```
+
+### Use `var` when reacting to changes with `.onChange()`
+
+```swift
+struct ReactiveView: View {
+    var externalValue: Int  // Watch with .onChange()
+    @State private var displayText = ""
+
+    var body: some View {
+        Text(displayText)
+            .onChange(of: externalValue) { oldValue, newValue in
+                displayText = "Changed from \(oldValue) to \(newValue)"
+            }
+    }
+}
+```
+
+## Environment and Preferences
+
+### @Environment
+
+Access environment values provided by SwiftUI or parent views:
+
+```swift
+struct MyView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        Button("Done") { dismiss() }
+            .foregroundStyle(colorScheme == .dark ? .white : .black)
+    }
+}
+```
+
+### @Environment with @Observable (iOS 17+ - Preferred)
+
+**Always prefer this pattern** for sharing state through the environment:
+
+```swift
+@Observable
+@MainActor
+final class AppState {
+    var isLoggedIn = false
+}
+
+// Inject
+ContentView()
+    .environment(AppState())
+
+// Access
+struct ChildView: View {
+    @Environment(AppState.self) private var appState
+}
+```
+
+### @EnvironmentObject (Legacy - Pre-iOS 17)
+
+Legacy pattern for sharing observable objects through the environment:
+
+```swift
+// Legacy pattern - use @Observable with @Environment instead
+class AppState: ObservableObject {
+    @Published var isLoggedIn = false
+}
+
+// Inject at root
+ContentView()
+    .environmentObject(AppState())
+
+// Access in child
+struct ChildView: View {
+    @EnvironmentObject var appState: AppState
+}
+```
+
+## Decision Flowchart
+
+```
+Is this value owned by this view?
+├─ YES: Is it a simple value type?
+│       ├─ YES → @State private var
+│       └─ NO (class):
+│           ├─ Use @Observable → @State private var (mark class @MainActor)
+│           └─ Legacy ObservableObject → @StateObject private var
+│
+└─ NO (passed from parent):
+    ├─ Does child need to MODIFY it?
+    │   ├─ YES → @Binding var
+    │   └─ NO: Does child need BINDINGS to its properties?
+    │       ├─ YES (@Observable) → @Bindable var
+    │       └─ NO: Does child react to changes?
+    │           ├─ YES → var + .onChange()
+    │           └─ NO → let
+    │
+    └─ Is it a legacy ObservableObject from parent?
+        └─ YES → @ObservedObject var (consider migrating to @Observable)
+```
+
+## State Privacy Rules
+
+**All view-owned state should be `private`:**
+
+```swift
+// Correct - clear what's created vs passed
+struct MyView: View {
+    // Created by view - private
+    @State private var isExpanded = false
+    @State private var viewModel = ViewModel()
+    @AppStorage("theme") private var theme = "light"
+    @Environment(\.colorScheme) private var colorScheme
+    
+    // Passed from parent - not private
+    let title: String
+    @Binding var isSelected: Bool
+    @Bindable var user: User
+    
+    var body: some View {
+        // ...
+    }
+}
+```
+
+**Why**: This makes dependencies explicit and improves code completion for the generated initializer.
+
+## Avoid Nested ObservableObject
+
+**Note**: This limitation only applies to `ObservableObject`. `@Observable` fully supports nested observed objects.
+
+```swift
+// Avoid - breaks animations and change tracking
+class Parent: ObservableObject {
+    @Published var child: Child  // Nested ObservableObject
+}
+
+class Child: ObservableObject {
+    @Published var value: Int
+}
+
+// Workaround - pass child directly to views
+struct ParentView: View {
+    @StateObject private var parent = Parent()
+    
+    var body: some View {
+        ChildView(child: parent.child)  // Pass nested object directly
+    }
+}
+
+struct ChildView: View {
+    @ObservedObject var child: Child
+    
+    var body: some View {
+        Text("\(child.value)")
+    }
+}
+```
+
+**Why**: SwiftUI can't track changes through nested `ObservableObject` properties. Manual workarounds break animations. With `@Observable`, this isn't an issue.
+
+## Key Principles
+
+1. **Always prefer `@Observable` over `ObservableObject`** for new code
+2. **Mark `@Observable` classes with `@MainActor` for thread safety (unless using default actor isolation)`**
+3. Use `@State` with `@Observable` classes (not `@StateObject`)
+4. Use `@Bindable` for injected `@Observable` objects that need bindings
+5. **Always mark `@State` and `@StateObject` as `private`**
+6. **Never declare passed values as `@State` or `@StateObject`**
+7. With `@Observable`, nested objects work fine; with `ObservableObject`, pass nested objects directly to child views

--- a/.codex/skills/swiftui-expert-skill/references/text-formatting.md
+++ b/.codex/skills/swiftui-expert-skill/references/text-formatting.md
@@ -1,0 +1,285 @@
+# SwiftUI Text Formatting Reference
+
+## Modern Text Formatting
+
+**Never use C-style `String(format:)` with Text. Always use format parameters.**
+
+## Number Formatting
+
+### Basic Number Formatting
+
+```swift
+let value = 42.12345
+
+// Modern (Correct)
+Text(value, format: .number.precision(.fractionLength(2)))
+// Output: "42.12"
+
+Text(abs(value), format: .number.precision(.fractionLength(2)))
+// Output: "42.12" (absolute value)
+
+// Legacy (Avoid)
+Text(String(format: "%.2f", abs(value)))
+```
+
+### Integer Formatting
+
+```swift
+let count = 1234567
+
+// With grouping separator
+Text(count, format: .number)
+// Output: "1,234,567" (locale-dependent)
+
+// Without grouping
+Text(count, format: .number.grouping(.never))
+// Output: "1234567"
+```
+
+### Decimal Precision
+
+```swift
+let price = 19.99
+
+// Fixed decimal places
+Text(price, format: .number.precision(.fractionLength(2)))
+// Output: "19.99"
+
+// Significant digits
+Text(price, format: .number.precision(.significantDigits(3)))
+// Output: "20.0"
+
+// Integer-only
+Text(price, format: .number.precision(.integerLength(1...)))
+// Output: "19"
+```
+
+## Currency Formatting
+
+```swift
+let price = 19.99
+
+// Correct - with currency code
+Text(price, format: .currency(code: "USD"))
+// Output: "$19.99"
+
+// With locale
+Text(price, format: .currency(code: "EUR").locale(Locale(identifier: "de_DE")))
+// Output: "19,99 €"
+
+// Avoid - manual formatting
+Text(String(format: "$%.2f", price))
+```
+
+## Percentage Formatting
+
+```swift
+let percentage = 0.856
+
+// Correct - with precision
+Text(percentage, format: .percent.precision(.fractionLength(1)))
+// Output: "85.6%"
+
+// Without decimal places
+Text(percentage, format: .percent.precision(.fractionLength(0)))
+// Output: "86%"
+
+// Avoid - manual calculation
+Text(String(format: "%.1f%%", percentage * 100))
+```
+
+## Date and Time Formatting
+
+### Date Formatting
+
+```swift
+let date = Date()
+
+// Date only
+Text(date, format: .dateTime.day().month().year())
+// Output: "Jan 23, 2026"
+
+// Full date
+Text(date, format: .dateTime.day().month(.wide).year())
+// Output: "January 23, 2026"
+
+// Short date
+Text(date, style: .date)
+// Output: "1/23/26"
+```
+
+### Time Formatting
+
+```swift
+let date = Date()
+
+// Time only
+Text(date, format: .dateTime.hour().minute())
+// Output: "2:30 PM"
+
+// With seconds
+Text(date, format: .dateTime.hour().minute().second())
+// Output: "2:30:45 PM"
+
+// 24-hour format
+Text(date, format: .dateTime.hour(.defaultDigits(amPM: .omitted)).minute())
+// Output: "14:30"
+```
+
+### Relative Date Formatting
+
+```swift
+let futureDate = Date().addingTimeInterval(3600)
+
+// Relative formatting
+Text(futureDate, style: .relative)
+// Output: "in 1 hour"
+
+Text(futureDate, style: .timer)
+// Output: "59:59" (counts down)
+```
+
+## String Searching and Comparison
+
+### Localized String Comparison
+
+**Use `localizedStandardContains()` for user-input filtering, not `contains()`.**
+
+```swift
+let searchText = "café"
+let items = ["Café Latte", "Coffee", "Tea"]
+
+// Correct - handles diacritics and case
+let filtered = items.filter { $0.localizedStandardContains(searchText) }
+// Matches "Café Latte"
+
+// Wrong - exact match only
+let filtered = items.filter { $0.contains(searchText) }
+// Might not match "Café Latte" depending on normalization
+```
+
+**Why**: `localizedStandardContains()` handles case-insensitive, diacritic-insensitive matching appropriate for user-facing search.
+
+### Case-Insensitive Comparison
+
+```swift
+let text = "Hello World"
+let search = "hello"
+
+// Correct - case-insensitive
+if text.localizedCaseInsensitiveContains(search) {
+    // Match found
+}
+
+// Also correct - for exact comparison
+if text.lowercased() == search.lowercased() {
+    // Equal
+}
+```
+
+### Localized Sorting
+
+```swift
+let names = ["Zoë", "Zara", "Åsa"]
+
+// Correct - locale-aware sorting
+let sorted = names.sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+// Output: ["Åsa", "Zara", "Zoë"]
+
+// Wrong - byte-wise sorting
+let sorted = names.sorted()
+// Output may not be correct for all locales
+```
+
+## Attributed Strings
+
+### Basic Attributed Text
+
+```swift
+// Using Text concatenation
+Text("Hello ")
+    .foregroundStyle(.primary)
++ Text("World")
+    .foregroundStyle(.blue)
+    .bold()
+
+// Using AttributedString
+var attributedString = AttributedString("Hello World")
+attributedString.foregroundColor = .primary
+if let range = attributedString.range(of: "World") {
+    attributedString[range].foregroundColor = .blue
+    attributedString[range].font = .body.bold()
+}
+Text(attributedString)
+```
+
+### Markdown in Text
+
+```swift
+// Simple markdown
+Text("This is **bold** and this is *italic*")
+
+// With links
+Text("Visit [Apple](https://apple.com) for more info")
+
+// Multiline markdown
+Text("""
+# Title
+This is a paragraph with **bold** text.
+- Item 1
+- Item 2
+""")
+```
+
+## Text Measurement
+
+### Measuring Text Height
+
+```swift
+// Wrong (Legacy) - GeometryReader trick
+struct MeasuredText: View {
+    let text: String
+    @State private var textHeight: CGFloat = 0
+    
+    var body: some View {
+        Text(text)
+            .background(
+                GeometryReader { geometry in
+                    Color.clear
+                        .onAppear {
+                            textWidth = geometry.size.height
+                        }
+                }
+            )
+    }
+}
+
+// Modern (correct)
+struct MeasuredText: View {
+    let text: String
+    @State private var textHeight: CGFloat = 0
+    
+    var body: some View {
+        Text(text)
+            .onGeometryChange(for: CGFloat.self) { geometry in
+                geometry.size.height
+            } action: { newValue in
+                textHeight = newValue
+            }
+    }
+}
+```
+
+## Summary Checklist
+
+- [ ] Use `.format` parameters with Text instead of `String(format:)`
+- [ ] Use `.currency(code:)` for currency formatting
+- [ ] Use `.percent` for percentage formatting
+- [ ] Use `.dateTime` for date/time formatting
+- [ ] Use `localizedStandardContains()` for user-input search
+- [ ] Use `localizedStandardCompare()` for locale-aware sorting
+- [ ] Use Text concatenation or AttributedString for styled text
+- [ ] Use markdown syntax for simple text formatting
+- [ ] All formatting respects user's locale and preferences
+
+**Why**: Modern format parameters are type-safe, localization-aware, and integrate better with SwiftUI's text rendering.

--- a/.codex/skills/swiftui-expert-skill/references/view-structure.md
+++ b/.codex/skills/swiftui-expert-skill/references/view-structure.md
@@ -1,0 +1,210 @@
+# SwiftUI View Structure Reference
+
+## View Structure Principles
+
+SwiftUI's diffing algorithm compares view hierarchies to determine what needs updating. Proper view composition directly impacts performance.
+
+## Prefer Modifiers Over Conditional Views
+
+**Prefer "no-effect" modifiers over conditionally including views.** When you introduce a branch, consider whether you're representing multiple views or two states of the same view.
+
+### Use Opacity Instead of Conditional Inclusion
+
+```swift
+// Good - same view, different states
+SomeView()
+    .opacity(isVisible ? 1 : 0)
+
+// Avoid - creates/destroys view identity
+if isVisible {
+    SomeView()
+}
+```
+
+**Why**: Conditional view inclusion can cause loss of state, poor animation performance, and breaks view identity. Using modifiers maintains view identity across state changes.
+
+### When Conditionals Are Appropriate
+
+Use conditionals when you truly have **different views**, not different states:
+
+```swift
+// Correct - fundamentally different views
+if isLoggedIn {
+    DashboardView()
+} else {
+    LoginView()
+}
+
+// Correct - optional content
+if let user {
+    UserProfileView(user: user)
+}
+```
+
+## Extract Subviews, Not Computed Properties
+
+### The Problem with @ViewBuilder Functions
+
+When you use `@ViewBuilder` functions or computed properties for complex views, the entire function re-executes on every parent state change:
+
+```swift
+// BAD - re-executes complexSection() on every tap
+struct ParentView: View {
+    @State private var count = 0
+
+    var body: some View {
+        VStack {
+            Button("Tap: \(count)") { count += 1 }
+            complexSection()  // Re-executes every tap!
+        }
+    }
+
+    @ViewBuilder
+    func complexSection() -> some View {
+        // Complex views that re-execute unnecessarily
+        ForEach(0..<100) { i in
+            HStack {
+                Image(systemName: "star")
+                Text("Item \(i)")
+                Spacer()
+                Text("Detail")
+            }
+        }
+    }
+}
+```
+
+### The Solution: Separate Structs
+
+Extract to separate `struct` views. SwiftUI can skip their `body` when inputs don't change:
+
+```swift
+// GOOD - ComplexSection body SKIPPED when its inputs don't change
+struct ParentView: View {
+    @State private var count = 0
+
+    var body: some View {
+        VStack {
+            Button("Tap: \(count)") { count += 1 }
+            ComplexSection()  // Body skipped during re-evaluation
+        }
+    }
+}
+
+struct ComplexSection: View {
+    var body: some View {
+        ForEach(0..<100) { i in
+            HStack {
+                Image(systemName: "star")
+                Text("Item \(i)")
+                Spacer()
+                Text("Detail")
+            }
+        }
+    }
+}
+```
+
+### Why This Works
+
+1. SwiftUI compares the `ComplexSection` struct (which has no properties)
+2. Since nothing changed, SwiftUI skips calling `ComplexSection.body`
+3. The complex view code never executes unnecessarily
+
+## When @ViewBuilder Functions Are Acceptable
+
+Use for small, simple sections that don't affect performance:
+
+```swift
+struct SimpleView: View {
+    @State private var showDetails = false
+
+    var body: some View {
+        VStack {
+            headerSection()  // OK - simple, few views
+            if showDetails {
+                detailsSection()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func headerSection() -> some View {
+        HStack {
+            Text("Title")
+            Spacer()
+            Button("Toggle") { showDetails.toggle() }
+        }
+    }
+
+    @ViewBuilder
+    private func detailsSection() -> some View {
+        Text("Some details here")
+            .font(.caption)
+    }
+}
+```
+
+## When to Extract Subviews
+
+Extract complex views into separate subviews when:
+- The view has multiple logical sections or responsibilities
+- The view contains reusable components
+- The view body becomes difficult to read or understand
+- You need to isolate state changes for performance
+- The view is becoming large (keep views small for better performance)
+
+## Container View Pattern
+
+### Avoid Closure-Based Content
+
+Closures can't be compared, causing unnecessary re-renders:
+
+```swift
+// BAD - closure prevents SwiftUI from skipping updates
+struct MyContainer<Content: View>: View {
+    let content: () -> Content
+
+    var body: some View {
+        VStack {
+            Text("Header")
+            content()  // Always called, can't compare closures
+        }
+    }
+}
+
+// Usage forces re-render on every parent update
+MyContainer {
+    ExpensiveView()
+}
+```
+
+### Use @ViewBuilder Property Instead
+
+```swift
+// GOOD - view can be compared
+struct MyContainer<Content: View>: View {
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack {
+            Text("Header")
+            content  // SwiftUI can compare and skip if unchanged
+        }
+    }
+}
+
+// Usage - SwiftUI can diff ExpensiveView
+MyContainer {
+    ExpensiveView()
+}
+```
+
+## Summary Checklist
+
+- [ ] Prefer modifiers over conditional views for state changes
+- [ ] Complex views extracted to separate subviews
+- [ ] Views kept small for better performance
+- [ ] `@ViewBuilder` functions only for simple sections
+- [ ] Container views use `@ViewBuilder let content: Content`
+- [ ] Extract views when they have multiple responsibilities or become hard to read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Completed tasks
 - Converted most user interfaces from xib files to storyboards, including the former `MainWindow.xib`.
 - Converted the preferences UI to Swift (`MUPreferencesViewController`).
 - Added a centralized **AVAudioEngine** capture pipeline with push-to-talk and VAD metering support.
+- Installed the SwiftUI expert Codex skill (`swiftui-expert`) under `.codex/skills` for this workspace.
 
 Open tasks
 ==========


### PR DESCRIPTION
### Motivation
- Ensure the on‑workspace SwiftUI Codex skill's declared name matches the documented usage so agents can load it consistently. 
- Provide a compact, local SwiftUI expertise skill with focused references and checklists to help the ongoing Swift migration and SwiftUI reviews. 
- Keep the migration tracking `AGENTS.md` accurate about the installed skill name.

### Description
- Renamed the skill metadata name to `swiftui-expert` in ` .codex/skills/swiftui-expert-skill/SKILL.md` so the skill identifier matches usage instructions. 
- Added a comprehensive SwiftUI expert skill payload under ` .codex/skills/swiftui-expert-skill/` including `SKILL.md` and multiple `references/*.md` (state management, view structure, performance, lists, layout, Liquid Glass, modern APIs, scroll/sheet/navigation patterns, image optimization, text formatting, etc.). 
- Updated `AGENTS.md` to reference the installed skill as `swiftui-expert` for clarity in the migration tracking. 
- Changes are documentation/skill-installation only and do not modify submodules or app source code.

### Testing
- Verified the modified `SKILL.md`, the added `references/` files, and the updated `AGENTS.md` are present in the workspace and contain the expected name and content. 
- No automated Xcode or unit tests were run because these are documentation/skill changes and Xcode-based testing is not possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977d8ff1f208330958ebb15c829fbe4)